### PR TITLE
[fix] simplify gRPC for create and open

### DIFF
--- a/src/protos/grpc/master_metadata_service.proto
+++ b/src/protos/grpc/master_metadata_service.proto
@@ -10,7 +10,11 @@ service MasterMetadataService {
   // chunk index and metadata. If |filename| already exists, it creates and
   // returns a new file chunk for the |filename|. If |filename| doesn't exist,
   // it creates the file and returns the first uninitialized empty chunk.
-  rpc CreateFileChunk(CreateFileRequest) returns (CreateFileReply) {}
+  //
+  // Since a Create is usually followed be read or write, we won't do lazy
+  // allocation for optimization here, and instead always create all metadata
+  // on relevant chunk servers. The request returns an error code, if it fails.
+  rpc CreateFileChunk(CreateFileChunkRequest) returns (CreateFileChunkReply) {}
 
   // Return the chunk handle, version, and associated replica locations
   // for a given |filename| at |chunk_index|. If either |filename| or
@@ -24,14 +28,15 @@ service MasterMetadataService {
   // TODO(tugan): add gRPC calls for snapshot operations
 }
 
-message CreateFileRequest {
+message CreateFileChunkRequest {
   // Absolute file name or directory name
   string filename = 1;
 }
 
-message CreateFileReply {
+// Chunk version is not returned here, as a new file always has a version of 1.
+message CreateFileChunkReply {
   // The original request associated with this reply.
-  CreateFileRequest request = 1;
+  CreateFileChunkRequest request = 1;
   // A chunk index is byte_range / chunk block size.
   // The default chunk block size is 64MB.
   uint32 chunk_index = 2;

--- a/src/protos/grpc/master_metadata_service.proto
+++ b/src/protos/grpc/master_metadata_service.proto
@@ -6,19 +6,24 @@ import "google/protobuf/empty.proto";
 import "src/protos/metadata.proto";
 
 service MasterMetadataService {
-  // Create a new file chunk for the |filename|, and return the associated
-  // chunk index and metadata. If |filename| already exists, it creates and
-  // returns a new file chunk for the |filename|. If |filename| doesn't exist,
-  // it creates the file and returns the first uninitialized empty chunk.
-  //
-  // Since a Create is usually followed be read or write, we won't do lazy
-  // allocation for optimization here, and instead always create all metadata
-  // on relevant chunk servers. The request returns an error code, if it fails.
-  rpc CreateFileChunk(CreateFileChunkRequest) returns (CreateFileChunkReply) {}
-
   // Return the chunk handle, version, and associated replica locations
-  // for a given |filename| at |chunk_index|. If either |filename| or
-  // |chunk_index| doesn't exist, an error status with empty reply is returned.
+  // for a given |filename| at |chunk_index|. 
+  //
+  // For |APPEND| mode, |chunk_index| is not required, ignored if specified, 
+  // because the master will decide which chunk handle the client should write 
+  // to for the append operation; if no concurrent append exists, this is 
+  // guaranteed to be the chunk handle for the last chunk index.
+  //
+  // If either |filename| or |chunk_index| doesn't exist, an error status with 
+  // empty reply is returned if |create_if_not_exists| is false; otherwise, the
+  // master will create the chunk, and initialize its creation on all chunk 
+  // servers, before returning to client. If chunk creation fails, the open
+  // operation is considered to have failed.
+  //
+  // The master does not enforce or guarantee a |filename| will always have
+  // continuous |chunk_index|. Fragmentation and missing intermediate chunks may 
+  // exist if client forgets, or fails, to create an intermediate |chunk_index|.
+  // In this case, it is up to the client to retry, when applicable.
   rpc OpenFile(OpenFileRequest) returns (OpenFileReply) {}
 
   // Delete |filename|. This effectively deletes all associated file chunks.
@@ -28,27 +33,12 @@ service MasterMetadataService {
   // TODO(tugan): add gRPC calls for snapshot operations
 }
 
-message CreateFileChunkRequest {
-  // Absolute file name or directory name
-  string filename = 1;
-}
-
-// Chunk version is not returned here, as a new file always has a version of 1.
-message CreateFileChunkReply {
-  // The original request associated with this reply.
-  CreateFileChunkRequest request = 1;
-  // A chunk index is byte_range / chunk block size.
-  // The default chunk block size is 64MB.
-  uint32 chunk_index = 2;
-  // The metadata associated with the file chunk at this chunk index
-  protos.FileChunkMetadata metadata = 3;
-}
-
 message OpenFileRequest {
   // Absolute file name or directory name
   string filename = 1;
   // A chunk index is |byte_range / chunk block size|.
   // By default, the block size of a chunk is 64MB.
+  // This is not required, and ignored, for |APPEND| mode.
   uint32 chunk_index = 2;
   // Open modes
   enum OpenMode {
@@ -57,6 +47,8 @@ message OpenFileRequest {
     APPEND = 2;
   }
   OpenMode mode = 3;
+  // Create the file chunk, if it doesn't exist
+  bool create_if_not_exists = 4;
 }
 
 message OpenFileReply {
@@ -66,11 +58,13 @@ message OpenFileReply {
   // The client, or another chunkserver, should always verify the chunk version
   // number before performing file operations at any chunk location, so that it
   // can always read/write the most up-to-date data.
+  //
+  // For newly created file chunks, chunk version is always 1.
   uint32 chunk_version = 2;
   // The metadata for the requested file chunk.
   protos.FileChunkMetadata metadata = 3;
   // If open request is for file mutation (i.e. write and append mode), this is
-  // the chunkserver location for the primary replicac; otherwise, it is NULL.
+  // the chunkserver location for the primary replica; otherwise, it is NULL.
   //
   // Client should send write requests to the primary chunkserver, so it can
   // determine the serialization order of all mutations applied to the chunk,


### PR DESCRIPTION
- added clarifications on the decision on whether or not we want to do lazy execution
- combined `CreateFileChunk` into `Open` gRPC with a `create_if_not_exist` mode, similar to linux's `O_CREATE`