### PR TITLE
[fix] make enum's first type be throwable unknown type

### DIFF
--- a/src/protos/grpc/chunk_server_file_service.proto
+++ b/src/protos/grpc/chunk_server_file_service.proto
@@ -53,8 +53,9 @@ message InitFileChunkReply {
   InitFileChunkRequest request = 1;
   // The status of file chunk creation operation
   enum InitFileChunkStatus {
-    CREATED = 0;
-    ALREADY_EXISTS = 1;
+    UNKNOWN = 0;
+    CREATED = 1;
+    ALREADY_EXISTS = 2;
   }
   InitFileChunkStatus status = 2;
 }
@@ -78,9 +79,10 @@ message ReadFileChunkReply {
   ReadFileChunkRequest request = 1;
   // The status of file chunk read operation
   enum ReadFileChunkStatus {
-    OK = 0;
-    FAILED_NOT_FOUND = 1;
-    FAILED_STALE_VERSION = 2;
+    UNKNOWN = 0;
+    OK = 1;
+    FAILED_NOT_FOUND = 2;
+    FAILED_STALE_VERSION = 3;
   }
   ReadFileChunkStatus status = 2;
   // The read data, if operation is successful
@@ -99,8 +101,9 @@ message AdvanceFileChunkVersionReply {
   AdvanceFileChunkVersionRequest request = 1;
   // The status of file chunk version update operation
   enum AdvanceFileChunkVersionStatus {
-    OK = 0;
-    FAILED_NOT_FOUND = 1;
+    UNKNOWN = 0;
+    OK = 1;
+    FAILED_NOT_FOUND = 2;
   }
   AdvanceFileChunkVersionStatus status = 2;
   // The new chunk version after the version advance
@@ -125,10 +128,11 @@ message WriteFileChunkReply {
   WriteFileChunkRequest request = 1;
   // The status of file chunk write operation
   enum WriteFileChunkStatus {
-    OK = 0;
-    FAILED_NOT_FOUND = 1;
-    FAILED_STALE_VERSION = 2;
-    FAILED_NOT_LEASE_HOLDER = 3;
+    UNKNOWN = 0;
+    OK = 1;
+    FAILED_NOT_FOUND = 2;
+    FAILED_STALE_VERSION = 3;
+    FAILED_NOT_LEASE_HOLDER = 4;
   }
   WriteFileChunkStatus status = 2;
   // The number of bytes that was actually written

--- a/src/protos/grpc/chunk_server_lease_service.proto
+++ b/src/protos/grpc/chunk_server_lease_service.proto
@@ -52,14 +52,15 @@ message GrantLeaseReply {
   GrantLeaseRequest request = 1;
   // The lease acceptance status by the chunk server
   enum GrantLeaseStatus {
+    UNKNOWN = 0;
     // The chunk server accepts the new lease
-    ACCEPTED = 0;
+    ACCEPTED = 1;
     // Request is ignored because it's already expired when received
-    IGNORED_EXPIRED_LEASE = 1;
+    IGNORED_EXPIRED_LEASE = 2;
     // Request is rejected because chunk server doesn't have this chunk handle
-    REJECTED_NOT_FOUND = 2;
+    REJECTED_NOT_FOUND = 3;
     // Request is rejected because chunk server has a stale version of the chunk
-    REJECTED_STALE_VERSION = 3;
+    REJECTED_STALE_VERSION = 4;
   }
   GrantLeaseStatus status = 2;
 }
@@ -76,12 +77,13 @@ message RevokeLeaseReply {
   RevokeLeaseRequest request = 1;
   // The lease revoke status by the chunk server
   enum RevokeLeaseStatus {
+    UNKNOWN = 0;
     // The chunk server has revoked its holding lease
-    REVOKED = 0;
+    REVOKED = 1;
     // Revoke is ignored because chunk server has a newer lease
-    IGNORED_HAS_NEWER_LEASE = 1;
+    IGNORED_HAS_NEWER_LEASE = 2;
     // Request is rejected because chunk server doesn't have this chunk handle
-    REJECTED_NOT_FOUND = 2;
+    REJECTED_NOT_FOUND = 3;
   }
   RevokeLeaseStatus status = 2;
 }

--- a/src/protos/grpc/master_metadata_service.proto
+++ b/src/protos/grpc/master_metadata_service.proto
@@ -43,9 +43,10 @@ message OpenFileRequest {
   uint32 chunk_index = 2;
   // Open modes
   enum OpenMode {
-    READ = 0;
-    WRITE = 1;
-    APPEND = 2;
+    UNKNOWN = 0;
+    READ = 1;
+    WRITE = 2;
+    APPEND = 3;
   }
   OpenMode mode = 3;
   // Create the file chunk, if it doesn't exist


### PR DESCRIPTION
As suggested by proto3, the first enum type is indistinguishable from being unset, default value, or set to first ENUM type, and thus is not sent over the wire by serialization, nor in debug string. To make it consistent with convention and for debugging, I added a 0-vauled UNKNOWN to all the prroto ENUMs