### PR TITLE
[feat + refactor] Use parallel-hashmap from library to manage concurrent access and update to master meatadata resources

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -7,7 +7,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_grpc_grpc//:grpc++",
+        "@com_google_absl//absl/synchronization",  
         "@com_google_protobuf//:protobuf_lite",
+        "@parallel_hashmap//:parallel_hashmap"
     ],
 )
 

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -26,6 +26,15 @@ class thread_safe_flat_hash_map
           std::allocator<std::pair<const K, V>>, /*submaps=*/4, absl::Mutex> {
 };
 
+// Similar as above, define an intrinsically thread-safe flat hash set
+template <class V>
+class thread_safe_flat_hash_set
+    : public phmap::parallel_flat_hash_set<
+          V, phmap::container_internal::hash_default_hash<V>,
+          phmap::container_internal::hash_default_eq<V>,
+          std::allocator<V>, /*submaps=*/4, absl::Mutex> {
+};
+
 namespace utils {
 
 // Convert a grpc::Status to protocol buffer's Status, so it's compatible with

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,11 +1,31 @@
 #ifndef GFS_COMMON_UTILS_H_
 #define GFS_COMMON_UTILS_H_
 
+#include "absl/synchronization/mutex.h"
 #include "google/protobuf/stubs/status.h"
 #include "grpcpp/grpcpp.h"
+#include "parallel_hashmap/phmap.h"
 
 namespace gfs {
 namespace common {
+
+// Define an intrinsically thread-safe flat hash map by parallel hashmap
+// The default definition assumes no internal lock and requires users
+// to pragmatically synchronize concurrent read and write to the parallel
+// hashmap. By passing a lock type, e.g. absl::Mutex, the parallel
+// hashmap is intrinsically thread safe.
+//
+// The example below follows the pattern defined in:
+// https://greg7mdp.github.io/parallel-hashmap/
+// https://github.com/greg7mdp/parallel-hashmap/blob/master/examples/bench.cc
+template <class K, class V>
+class thread_safe_flat_hash_map
+    : public phmap::parallel_flat_hash_map<
+          K, V, phmap::container_internal::hash_default_hash<K>,
+          phmap::container_internal::hash_default_eq<K>,
+          std::allocator<std::pair<const K, V>>, /*submaps=*/4, absl::Mutex> {
+};
+
 namespace utils {
 
 // Convert a grpc::Status to protocol buffer's Status, so it's compatible with

--- a/src/server/master_server/BUILD.bazel
+++ b/src/server/master_server/BUILD.bazel
@@ -16,6 +16,7 @@ cc_library(
     hdrs = ["lock_manager.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/common:utils",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/synchronization",
         "@com_google_protobuf//:protobuf_lite",

--- a/src/server/master_server/lock_manager.cc
+++ b/src/server/master_server/lock_manager.cc
@@ -18,7 +18,7 @@ google::protobuf::util::StatusOr<absl::Mutex*> LockManager::CreateLock(
     const std::string& filename) {
   // The emplace method returns a pair, where the first field corresponds 
   // to the item for this key, and the second field is true if this 
-  // this call successfully inserts an item, and is false if there
+  // call successfully inserts an item, and is false if there
   // is already an item existed for the given key. We use the second field
   // to detect whether a lock has been created already (or there is another
   // racing thread that inserted one before this call). 
@@ -46,7 +46,7 @@ google::protobuf::util::StatusOr<absl::Mutex*> LockManager::CreateLock(
 google::protobuf::util::StatusOr<absl::Mutex*> LockManager::FetchLock(
     const std::string& filename) const {
   // Again, note that we do not fully support crazy schemes like 
-  // concurrent create and delete. Otherwise, the following pattern
+  // concurrent create and delete locks. Otherwise, the following pattern
   // may seem to have a time-of-check-time-of-use bug, namely the lock
   // got removed in the two lines between. Furthermore, it may seem
   // tempting to just use the operator [] and a null check to 

--- a/src/server/master_server/lock_manager.cc
+++ b/src/server/master_server/lock_manager.cc
@@ -10,50 +10,55 @@ using google::protobuf::util::StatusOr;
 namespace gfs {
 namespace server {
 
-/* A private helper class to compute the index in the file_path_locks_
- * collection for a pathanme. */
-inline uint16_t LockManager::bucket_id(const std::string& filename) const {
-  return std::hash<std::string>{}(filename) % shard_size_;
-}
-
-/* Initialize the meta locks and the vector of filePathLocks  */
-LockManager::LockManager() {
-  shard_size_ = std::max(std::thread::hardware_concurrency(), (unsigned int)1);
-  meta_locks_ = std::vector<absl::Mutex*>(shard_size_, new absl::Mutex());
-  file_path_locks_ =
-      std::vector<absl::flat_hash_map<std::string, absl::Mutex*>>(shard_size_);
-}
-
 bool LockManager::Exist(const std::string& filename) const {
-  auto idx(bucket_id(filename));
-  absl::MutexLock lock_guard(meta_locks_[idx]);
-  return file_path_locks_[idx].contains(filename);
+  return file_path_locks_.contains(filename);
 }
 
 google::protobuf::util::StatusOr<absl::Mutex*> LockManager::CreateLock(
     const std::string& filename) {
-  auto idx(bucket_id(filename));
-  absl::MutexLock lock_guard(meta_locks_[idx]);
-  if (file_path_locks_[idx].contains(filename)) {
+  // The emplace method returns a pair, where the first field corresponds 
+  // to the item for this key, and the second field is true if this 
+  // this call successfully inserts an item, and is false if there
+  // is already an item existed for the given key. We use the second field
+  // to detect whether a lock has been created already (or there is another
+  // racing thread that inserted one before this call). 
+  auto new_lock(std::shared_ptr<absl::Mutex>(new absl::Mutex()));
+  auto lock_and_if_took_place(file_path_locks_.emplace(filename,new_lock));
+  bool has_insert_taken_place(lock_and_if_took_place.second);
+  if (!has_insert_taken_place) {
     return Status(google::protobuf::util::error::ALREADY_EXISTS,
                   "Lock already exists for " + filename);
   }
-
-  auto ret(new absl::Mutex());
-  file_path_locks_[idx][filename] = ret;
-  return ret;
+  // TODO: We have not finalized the plan regarding to the removal of locks.
+  // The simplest approach is to say we don't remove locks (note that not 
+  // removing locks doesn't equate to not removing files) so we won't have 
+  // an issue that a removal takes place between the above and code below. 
+  // This may seem too restricted, but dealing with concurrent creation and
+  // deletion is a pain and having a full-support of this may be rather 
+  // an overkill. What we can do instead is to defer the deletion of 
+  // lock resources (they are relatively small comparing to file metadata)
+  // and say, let's remove the lock resources only after the actual chunk 
+  // resources got garbage collected. Let's see how far we can go with this 
+  // project and see if we get a chance to improve the design here. 
+  return new_lock.get();
 }
 
 google::protobuf::util::StatusOr<absl::Mutex*> LockManager::FetchLock(
     const std::string& filename) const {
-  auto idx(std::hash<std::string>{}(filename) % shard_size_);
-  absl::MutexLock lock_guard(meta_locks_[idx]);
-  if (!file_path_locks_[idx].contains(filename)) {
+  // Again, note that we do not fully support crazy schemes like 
+  // concurrent create and delete. Otherwise, the following pattern
+  // may seem to have a time-of-check-time-of-use bug, namely the lock
+  // got removed in the two lines between. Furthermore, it may seem
+  // tempting to just use the operator [] and a null check to 
+  // accomplish this, but the problem is that it makes this function
+  // invasive and can insert a default item underneath, this can 
+  // interact with the CreateLock function above and cause an empty
+  // share_ptr ended up for a lock, which is obviously not great. 
+  if (!Exist(filename)) {
     return Status(google::protobuf::util::error::NOT_FOUND,
                   "Lock does not exist for " + filename);
   }
-
-  return file_path_locks_[idx].at(filename);
+  return file_path_locks_.at(filename).get();
 }
 
 LockManager* LockManager::GetInstance() {

--- a/src/server/master_server/lock_manager.h
+++ b/src/server/master_server/lock_manager.h
@@ -12,41 +12,38 @@
 namespace gfs {
 namespace server {
 
-/* The LockManager handles how we do resource locking for read/write/create to
- * our file system. This objects provides locks according to file path name, and
- * it manages the locks by mapping filename to actual lock objects. Furthermore,
- * it shards the mapping space by storing multiple maps in an array, and for
- * each path name it finds the corresponding map by computing the hash of this
- * path (and mod by the total number of available cores). This is effectively a
- * parallel hash map for locks.
- *
- * The reason for this design is that even though we meant to use the lock
- * objects to lock namespace, these locks are not created ahead of time because
- * we do not now the filename. So all the creation of locks need to be
- * synchronized with the access to them. Without sharding them into multiple
- * maps, this synchronization is a potential bottle neck when concurrent
- * creation and read request are made to the master. We introduce an internal
- * vector of "meta locks" to manage the synchronization of each maps.
- *
- * The LockManager supports methods to check whether a path name exists, add a
- * lock for a given path name and get a lock.
- */
+// The LockManager handles how we do resource locking for read/write/create to
+// our file system. This objects provides locks according to file path name, and
+// it manages the locks by mapping filename to actual lock objects. Furthermore,
+// it shards the mapping space by storing multiple maps in an array, and for
+// each path name it finds the corresponding map by computing the hash of this
+// path (and mod by the total number of available cores). This is effectively a
+// parallel hash map for locks.
+//
+// The reason for this design is that even though we meant to use the lock
+// objects to lock namespace, these locks are not created ahead of time because
+// we do not now the filename. So all the creation of locks need to be
+// synchronized with the access to them. Without sharding them into multiple
+// maps, this synchronization is a potential bottle neck when concurrent
+// creation and read request are made to the master. We introduce an internal
+// vector of "meta locks" to manage the synchronization of each maps.
+//
+// The LockManager supports methods to check whether a path name exists, add a
+// lock for a given path name and get a lock.
 class LockManager {
  public:
-  /* Methods to check the existence of the lock for a given path, add a lock and
-   * access a lock*/
+  // Check the existence of a lock given a filename
   bool Exist(const std::string& filename) const;
 
-  /* Create a lock for a given path, return error if the lock already exists */
+  // Create a lock for a given path, return error if the lock already exists
   google::protobuf::util::StatusOr<absl::Mutex*> CreateLock(
       const std::string& filename);
 
-  /* Retrieve a lock for a given path, return error if the lock does not exist
-   */
+  // Retrieve a lock for a given path, return error if the lock does not exist
   google::protobuf::util::StatusOr<absl::Mutex*> FetchLock(
       const std::string& filename) const;
 
-  /* Get the instance of the LockManager, which is a singleton */
+  // Get the instance of the LockManager, which is a singleton
   static LockManager* GetInstance();
 
  private:
@@ -56,12 +53,11 @@ class LockManager {
       std::string, std::shared_ptr<absl::Mutex>> file_path_locks_;
 };
 
-/* A helper class which is an RAII wrapper to automatically acquire reader
- * locks for all the parent directories of a given path name. It stores
- * the relevant locks that are acquired in sequence (from the root one to
- * the immediate parent directory) in a stack, and releases these locks upon
- * destruction.
- * */
+// A helper class which is an RAII wrapper to automatically acquire reader
+// locks for all the parent directories of a given path name. It stores
+// the relevant locks that are acquired in sequence (from the root one to
+// the immediate parent directory) in a stack, and releases these locks upon
+// destruction.
 class ParentLocksAnchor {
  public:
   ParentLocksAnchor(LockManager* lock_manager, const std::string& filename);

--- a/src/server/master_server/metadata_manager.cc
+++ b/src/server/master_server/metadata_manager.cc
@@ -34,6 +34,9 @@ google::protobuf::util::Status MetadataManager::CreateFileMetadata(
   // to detect if the creation took place (as there can be concurrent
   // creation in rare cases, and only one succeeds). 
   auto new_file_metadata(std::make_shared<FileMetadata>());
+  // Initialize filename
+  new_file_metadata->set_filename(filename);
+  
   auto new_file_metadata_and_if_took_place(
            file_metadata_.emplace(filename, new_file_metadata));
   auto has_create_taken_place(new_file_metadata_and_if_took_place.second);
@@ -44,8 +47,6 @@ google::protobuf::util::Status MetadataManager::CreateFileMetadata(
         "File metadata already exists for " + filename);
   }
 
-  // Initialize the filename
-  new_file_metadata->set_filename(filename);
   return google::protobuf::util::Status::OK;
 }
 

--- a/src/server/master_server/metadata_manager.cc
+++ b/src/server/master_server/metadata_manager.cc
@@ -9,7 +9,6 @@ namespace server {
 
 MetadataManager::MetadataManager() {
   lock_manager_ = LockManager::GetInstance();
-  file_metadata_lock_ = new absl::Mutex();
 }
 
 google::protobuf::util::Status MetadataManager::CreateFileMetadata(
@@ -26,39 +25,47 @@ google::protobuf::util::Status MetadataManager::CreateFileMetadata(
   // Step 2. Add a new lock for this new file, and writeLock it
   auto path_lock_or(lock_manager_->CreateLock(filename));
   if (!path_lock_or.ok()) {
-    // We still need to check whether the return is NULL because another thread
-    // could well successfully created a new lock for the same path
     return path_lock_or.status();
   }
 
   absl::WriterMutexLock path_writer_lock_guard(path_lock_or.ValueOrDie());
-  // Step 3. writeLock the global lock, instantiate a FileMetadata object
-  absl::WriterMutexLock file_metadata_writer_lock_guard(file_metadata_lock_);
-  // The reason that we acquire the global lock is that we need to
-  // synchronization between write and read from the fileMetadata collection.
-  if (file_metadata_.contains(filename)) {
+  
+  // Step 3. Instantiate a FileMetadata object. Use the emplace function 
+  // to detect if the creation took place (as there can be concurrent
+  // creation in rare cases, and only one succeeds). 
+  auto new_file_metadata(std::make_shared<FileMetadata>());
+  auto new_file_metadata_and_if_took_place(
+           file_metadata_.emplace(filename, new_file_metadata));
+  auto has_create_taken_place(new_file_metadata_and_if_took_place.second);
+
+  if (!has_create_taken_place) {
     return google::protobuf::util::Status(
         google::protobuf::util::error::ALREADY_EXISTS,
         "File metadata already exists for " + filename);
   }
 
-  file_metadata_[filename] = std::make_shared<FileMetadata>();
   // Initialize the filename
-  file_metadata_[filename]->set_filename(filename);
+  new_file_metadata->set_filename(filename);
   return google::protobuf::util::Status::OK;
 }
 
 bool MetadataManager::ExistFileMetadata(const std::string& filename) const {
-  absl::ReaderMutexLock reader_lock_guard(file_metadata_lock_);
   return file_metadata_.contains(filename);
 }
 
 google::protobuf::util::StatusOr<std::shared_ptr<FileMetadata>>
 MetadataManager::GetFileMetadata(const std::string& filename) const {
-  // readLock the global lock and retrieve the filemetadata. The reason for a
-  // readLock is because we are not mutating anything in the file_metadata_.
-  absl::ReaderMutexLock reader_lock_guard(file_metadata_lock_);
-  if (!file_metadata_.contains(filename)) {
+  // Note that there is a null check for the filemetadata below. See 
+  // comments in the DeleteFile function. This is to deal with deletion,
+  // if we simply remove the item from file_metadata_ when we delete,
+  // we may run into time-of-check-time-of-use issue (though rare) 
+  // in this function because you can check it and find it exists but
+  // then access it and find it not. What we can do instead is to
+  // replace the share_ptr with a default one (with a null raw ptr
+  // underneath) upon deletion. This way, the .at() function succeeds. 
+  // Regarding to the final removal of this filename, we defer it 
+  // until the final garbage collection of the file chunks. 
+  if (!file_metadata_.contains(filename) || !file_metadata_.at(filename)) {
     return google::protobuf::util::Status(
         google::protobuf::util::error::NOT_FOUND,
         "File metadata does not exist: " + filename);
@@ -77,7 +84,7 @@ MetadataManager::CreateChunkHandle(const std::string& filename,
     return parentLockAnchor.status();
   }
 
-  // Step 2. readlock the global lock, fetch the data and unlock readerlock
+  // Step 2. fetch the file metadata
   auto file_metadata_or(GetFileMetadata(filename));
   if (!file_metadata_or.ok()) {
     return file_metadata_or.status();
@@ -96,7 +103,6 @@ MetadataManager::CreateChunkHandle(const std::string& filename,
 
   // Step 4. compute a new chunk handle, and insert the (chunk_index,
   // chunkHandle)
-  //         pair to file_metadata_
   std::string new_chunk_handle(AllocateNewChunkHandle());
   file_metadata->set_filename(filename);
   auto& chunk_handle_map(*file_metadata->mutable_chunk_handles());
@@ -113,6 +119,12 @@ MetadataManager::CreateChunkHandle(const std::string& filename,
   return new_chunk_handle;
 }
 
+// TODO(Xi): In phase 1 the deletion of file is not fully supported but
+// it would be good to lay out a plan as deletion involves removing items
+// from the shared states. For Filemetadata, the proposed plan here is 
+// to replace the File metadata with a default shared_ptr, and defer
+// the final cleanup to the point when the chunks have been garbage
+// collected. 
 void MetadataManager::DeleteFile(const std::string& filename) {
   // [TODO]: phase 2
 }

--- a/src/server/master_server/metadata_manager.h
+++ b/src/server/master_server/metadata_manager.h
@@ -10,68 +10,66 @@
 namespace gfs {
 namespace server {
 
-/* The MetadataManager manages the following resources that are central to the
- * master node in GFS.
- * 1) the assignment of chunk handle, which is a UUID.
- * 2) the mapping between a file name to the chunk handles associated with it.
- * 3) the set of deleted chunk handles.
- *
- * The MetadataManager provides the following thread-safe methods:
- * 1) create a (default) file metadata for a given file. This involves also the
- *    creation of underlying locks associated with this file.
- * 2) get the file metadata for a given file
- * 3) create a file chunk handle
- * 4) delete a file, this involves the deletion of all chunk handles assigned to
- *    this file.
- * 5) assigning new chunk handle, this provides a unique UUID each time when the
- *    function is called.
- *
- * TODO(Xi): TBD whether to put chunk location and version information in this
- * MetadataManager
- */
-
+// The MetadataManager manages the following resources that are central to the
+// master node in GFS.
+// 1) the assignment of chunk handle, which is a UUID.
+// 2) the mapping between a file name to the chunk handles associated with it.
+// 3) the set of deleted chunk handles.
+//
+// The MetadataManager provides the following thread-safe methods:
+// 1) create a (default) file metadata for a given file. This involves also the
+//    creation of underlying locks associated with this file.
+// 2) get the file metadata for a given file
+// 3) create a file chunk handle
+// 4) delete a file, this involves the deletion of all chunk handles assigned to
+//    this file.
+// 5) assigning new chunk handle, this provides a unique UUID each time when the
+//    function is called.
+//
+// TODO(Xi): TBD whether to put chunk location and version information in this
+// MetadataManager
 class MetadataManager {
  public:
   MetadataManager();
 
-  /* Create the file metadata (and a lock associated with this file) for a
-   * given file path. This function returns error if the file path already
-   * exists or if any of the intermediate parent directory does not exist. */
+  // Create the file metadata (and a lock associated with this file) for a
+  // given file path. This function returns error if the file path already
+  // exists or if any of the intermediate parent directory does not exist.
   google::protobuf::util::Status CreateFileMetadata(
       const std::string& filename);
 
-  /* Check if metadata file a file exists */
+  // Check if metadata file a file exists
   bool ExistFileMetadata(const std::string& filename) const;
 
-  /* Access the file metadata for a given file path. The caller of this
-   * function needs to ensure the lock for this file is properly used.
-   * return error if fileMetadata does not exist */
+  // Access the file metadata for a given file path. The caller of this
+  // function needs to ensure the lock for this file is properly used.
+  // return error if fileMetadata does not exist
   google::protobuf::util::StatusOr<std::shared_ptr<protos::FileMetadata>>
-  GetFileMetadata(const std::string& filename) const;
+      GetFileMetadata(const std::string& filename) const;
 
-  /* Create a file chunk for a given filename and a chunk index.  */
+  // Create a file chunk for a given filename and a chunk index.
   google::protobuf::util::StatusOr<std::string> CreateChunkHandle(
       const std::string& filename, uint32_t chunk_index);
 
-  /* Delete a file, and delete all chunk handles associated with this file */
+  // Delete a file, and delete all chunk handles associated with this file
   void DeleteFile(const std::string& filename);
 
-  /* Assign a new chunk handle. This function returns a unique chunk handle
-   * everytime when it gets called */
+  // Assign a new chunk handle. This function returns a unique chunk handle
+  // everytime when it gets called
   std::string AllocateNewChunkHandle();
 
-  /* Instance function to access the singleton */
+  // Instance function to access the singleton
   static MetadataManager* GetInstance();
 
  private:
-  /* An atomic uint64 used to assign UUID for each chunk */
+  // An atomic uint64 used to assign UUID for each chunk
   std::atomic<uint64_t> global_chunk_id_{0};
-  /* Store all deleted chunk handles in a hashset  */
+  // Store all deleted chunk handles in a thread-safe hashset
   gfs::common::thread_safe_flat_hash_set<std::string> deleted_chunk_handles_;
-  /* Map from file path to FileMetadata */
+  // Map from file path to FileMetadata using a thread-safe hashmap
   gfs::common::thread_safe_flat_hash_map<
       std::string, std::shared_ptr<protos::FileMetadata>> file_metadata_;
-  /* Lock manager to manager the synchronization of operations */
+  // Lock manager to manager the synchronization of operations
   LockManager* lock_manager_;
 };
 

--- a/src/server/master_server/metadata_manager.h
+++ b/src/server/master_server/metadata_manager.h
@@ -3,6 +3,7 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "google/protobuf/stubs/statusor.h"
+#include "src/common/utils.h"
 #include "src/protos/metadata.pb.h"
 #include "src/server/master_server/lock_manager.h"
 
@@ -66,14 +67,12 @@ class MetadataManager {
   /* An atomic uint64 used to assign UUID for each chunk */
   std::atomic<uint64_t> global_chunk_id_{0};
   /* Store all deleted chunk handles in a hashset  */
-  absl::flat_hash_set<std::string> deleted_chunk_handles_;
+  gfs::common::thread_safe_flat_hash_set<std::string> deleted_chunk_handles_;
   /* Map from file path to FileMetadata */
-  absl::flat_hash_map<std::string, std::shared_ptr<protos::FileMetadata>>
-      file_metadata_;
+  gfs::common::thread_safe_flat_hash_map<
+      std::string, std::shared_ptr<protos::FileMetadata>> file_metadata_;
   /* Lock manager to manager the synchronization of operations */
   LockManager* lock_manager_;
-  /* A lock to lock file_metadata_ */
-  absl::Mutex* file_metadata_lock_;
 };
 
 }  // namespace server

--- a/tests/server/master_server/metadata_manager_unit_test.cc
+++ b/tests/server/master_server/metadata_manager_unit_test.cc
@@ -8,32 +8,45 @@ using namespace gfs::server;
 
 class MetadataManagerUnitTest : public ::testing::Test {
  protected:
-  void SetUp() override { metadataManager_ = MetadataManager::GetInstance(); }
+  void SetUp() override { metadata_manager_ = MetadataManager::GetInstance(); }
 
-  MetadataManager* metadataManager_;
+  MetadataManager* metadata_manager_;
 };
 
 // Helper function to join a colletion of threads and cleanup the container for
 // these threads
-void joinAndClearThreads(std::vector<std::thread>& threads) {
+void JoinAndClearThreads(std::vector<std::thread>& threads) {
   for (auto& t : threads) {
     t.join();
   }
   threads.clear();
 }
 
+// Helper function to compute a filename given a base string and a nested 
+// level. The name scheme takes the following form:
+// "/{base}0/{base}1/..../{base}{nested_level-1}"
+std::string ComputeNestedFileName(const std::string& base, 
+                                  const int nested_level) {
+  std::string filename;
+  for (int i = 0; i < nested_level; i++) {
+    filename += ("/" + base + std::to_string(i));
+  }
+  return filename;
+}
+
+
 // The simplest case that one creates a file /foo, and add a file chunk
 TEST_F(MetadataManagerUnitTest, CreateSingleFileMetadata) {
-  auto create_metadata(metadataManager_->CreateFileMetadata("/foo"));
+  auto create_metadata(metadata_manager_->CreateFileMetadata("/foo"));
   EXPECT_TRUE(create_metadata.ok());
 
-  EXPECT_TRUE(metadataManager_->ExistFileMetadata("/foo"));
-  auto foo_metadata_or(metadataManager_->GetFileMetadata("/foo"));
+  EXPECT_TRUE(metadata_manager_->ExistFileMetadata("/foo"));
+  auto foo_metadata_or(metadata_manager_->GetFileMetadata("/foo"));
   EXPECT_TRUE(foo_metadata_or.ok());
   auto foo_metadata(foo_metadata_or.ValueOrDie());
   EXPECT_EQ(foo_metadata->filename(), "/foo");
 
-  auto first_chunk_handle_or(metadataManager_->CreateChunkHandle("/foo", 0));
+  auto first_chunk_handle_or(metadata_manager_->CreateChunkHandle("/foo", 0));
   EXPECT_TRUE(first_chunk_handle_or.ok());
   auto first_chunk_handle(first_chunk_handle_or.ValueOrDie());
   EXPECT_EQ(first_chunk_handle, "0");
@@ -47,24 +60,24 @@ TEST_F(MetadataManagerUnitTest, CreateMultiFileMetadataInParallel) {
   std::vector<std::thread> threads;
   for (int i = 0; i < numOfThreads; i++) {
     threads.push_back(std::thread([&, i]() {
-      auto file_name("/" + std::to_string(i));
-      metadataManager_->CreateFileMetadata(file_name);
-      metadataManager_->CreateChunkHandle(file_name, 0);
+      auto filename("/" + std::to_string(i));
+      metadata_manager_->CreateFileMetadata(filename);
+      metadata_manager_->CreateChunkHandle(filename, 0);
     }));
   }
 
   // Join all threads
-  joinAndClearThreads(threads);
+  JoinAndClearThreads(threads);
 
   std::set<std::string> unique_id;
   for (int i = 0; i < numOfThreads; i++) {
-    auto file_name("/" + std::to_string(i));
+    auto filename("/" + std::to_string(i));
     // Ensure that the files are created successfully
-    EXPECT_TRUE(metadataManager_->ExistFileMetadata(file_name));
-    auto file_metadata_or(metadataManager_->GetFileMetadata(file_name));
+    EXPECT_TRUE(metadata_manager_->ExistFileMetadata(filename));
+    auto file_metadata_or(metadata_manager_->GetFileMetadata(filename));
     EXPECT_TRUE(file_metadata_or.ok());
     auto file_metadata(file_metadata_or.ValueOrDie());
-    EXPECT_EQ(file_metadata->filename(), file_name);
+    EXPECT_EQ(file_metadata->filename(), filename);
     auto& chunk_handles(*file_metadata->mutable_chunk_handles());
     // Ensure that chunk handle exists for chunk_index 0 for each file
     EXPECT_EQ(chunk_handles.count(0), 1);
@@ -82,13 +95,13 @@ TEST_F(MetadataManagerUnitTest, CreateMultiFileMetadataInParallel) {
 TEST_F(MetadataManagerUnitTest, CreateSingleFileMultiChunksInParallel) {
   auto numOfThreads(10);
   std::vector<std::thread> threads;
-  auto file_name("/sameFile");
+  auto filename("/sameFile");
   std::atomic<int> cnts{0};
 
   // Create the same file concurrently
   for (int i = 0; i < numOfThreads; i++) {
     threads.push_back(std::thread([&, i]() {
-      auto create_metadata(metadataManager_->CreateFileMetadata(file_name));
+      auto create_metadata(metadata_manager_->CreateFileMetadata(filename));
       if (create_metadata.ok()) {
         cnts++;
       }
@@ -96,7 +109,7 @@ TEST_F(MetadataManagerUnitTest, CreateSingleFileMultiChunksInParallel) {
   }
 
   // Join all threads and clear up
-  joinAndClearThreads(threads);
+  JoinAndClearThreads(threads);
 
   // Only one of the create function succeeds because it is the same file
   EXPECT_EQ(cnts.load(), 1);
@@ -104,16 +117,16 @@ TEST_F(MetadataManagerUnitTest, CreateSingleFileMultiChunksInParallel) {
   // Create disjoint chunk handles concurrently
   for (int i = 0; i < numOfThreads; i++) {
     threads.push_back(std::thread(
-        [&, i]() { metadataManager_->CreateChunkHandle(file_name, i); }));
+        [&, i]() { metadata_manager_->CreateChunkHandle(filename, i); }));
   }
 
   // Join all threads
-  joinAndClearThreads(threads);
+  JoinAndClearThreads(threads);
 
-  auto file_metadata_or(metadataManager_->GetFileMetadata(file_name));
+  auto file_metadata_or(metadata_manager_->GetFileMetadata(filename));
   EXPECT_TRUE(file_metadata_or.ok());
   auto file_metadata(file_metadata_or.ValueOrDie());
-  EXPECT_EQ(file_metadata->filename(), file_name);
+  EXPECT_EQ(file_metadata->filename(), filename);
   std::set<std::string> unique_id;
   EXPECT_EQ(file_metadata->chunk_handles_size(), numOfThreads);
   auto& chunk_handles(*file_metadata->mutable_chunk_handles());
@@ -125,37 +138,170 @@ TEST_F(MetadataManagerUnitTest, CreateSingleFileMultiChunksInParallel) {
   EXPECT_EQ(unique_id.size(), numOfThreads);
 }
 
+// Multiple threads create file chunks but some of the indexes are 
+// overlaping, so some of the CreateFileChunk calls fails
+// Verify that the final state of filemetadata is legitimate
+TEST_F(MetadataManagerUnitTest, ConcurrentChunkCreationOverlap) {
+  int num_of_threads(24);
+  int num_of_chunk_per_file(100);
+  std::string filename("/ConcurrentChunkCreationOverlap");
+  std::vector<std::thread> threads;
+  
+  // First create a file
+  auto create_file_status(metadata_manager_->CreateFileMetadata(filename));
+  EXPECT_TRUE(create_file_status.ok());
+  
+  // A counter to count how many CreateChunkHandle actually fail 
+  // (as expected)
+  std::atomic<int> cnt_fail{0};
+
+  // Concurrent creation of chunks for the same file, so some of them 
+  // must fail
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      for (int chunk_id = 0; chunk_id < num_of_chunk_per_file; chunk_id++) {
+        auto create_chunk_handle_or(
+                 metadata_manager_->CreateChunkHandle(filename, chunk_id));
+        if (!create_chunk_handle_or.ok()) {
+          EXPECT_EQ(create_chunk_handle_or.status().error_code(),
+                    google::protobuf::util::error::ALREADY_EXISTS);
+          cnt_fail++;
+        }
+      }
+    }));
+  }
+
+  JoinAndClearThreads(threads);
+
+  // There are in total num_of_threads * num_of_chunk_per_file chunk creation
+  // attempt, but only for chunk 0,...,num_of_chunk_per_file-1 of one file
+  // Therefore, only num_of_chunk_per_file attempts succeeded and the rest
+  // would fail. 
+  EXPECT_EQ(cnt_fail.load(), (num_of_threads-1) * num_of_chunk_per_file);
+  
+  // Verify that the the expected number of chunks are created for the file
+  auto file_metadata_or(metadata_manager_->GetFileMetadata(filename));
+  EXPECT_TRUE(file_metadata_or.ok());
+  auto file_metadata(file_metadata_or.ValueOrDie());
+  EXPECT_EQ(file_metadata->chunk_handles_size(), num_of_chunk_per_file);
+}
+
 // Check error messages for a few different cases
 // 1) Create a file metadata and then create it again
 // 2) Get a a non-existing file metadata
 // 3) Create a chunk index for a non-existing file
 // 4) Create a chunk index for a file twice
-TEST_F(MetadataManagerUnitTest, CheckErrorMessages) {
-  auto new_file_name("/newFile");
-  auto create_metadata(metadataManager_->CreateFileMetadata(new_file_name));
+TEST_F(MetadataManagerUnitTest, CheckErrorCases) {
+  auto new_filename("/newFile");
+  auto create_metadata(metadata_manager_->CreateFileMetadata(new_filename));
   EXPECT_TRUE(create_metadata.ok());
   auto duplicate_create_metadata_or(
-      metadataManager_->CreateFileMetadata(new_file_name));
-  // Note: ideally here we should say file metadata already exists. But before
-  // creating a file metadata we always first create a lock. If the lock already
-  // exsits we return early. Improvement could be done by handling the error
-  // returned from the lockManager
-  EXPECT_EQ(duplicate_create_metadata_or.error_message(),
-            "Lock already exists for /newFile");
+      metadata_manager_->CreateFileMetadata(new_filename));
+  EXPECT_EQ(duplicate_create_metadata_or.error_code(),
+            google::protobuf::util::error::ALREADY_EXISTS);
 
   auto non_exist_file("/nonExist");
-  auto non_exist_metadata_or(metadataManager_->GetFileMetadata(non_exist_file));
-  EXPECT_EQ(non_exist_metadata_or.status().error_message(),
-            "File metadata does not exist: /nonExist");
+  auto non_exist_metadata_or(
+           metadata_manager_->GetFileMetadata(non_exist_file));
+  EXPECT_EQ(non_exist_metadata_or.status().error_code(),
+            google::protobuf::util::error::NOT_FOUND);
 
   auto non_exist_chunk_handle(
-      metadataManager_->CreateChunkHandle(non_exist_file, 0));
-  EXPECT_EQ(non_exist_chunk_handle.status().error_message(),
-            "File metadata does not exist: /nonExist");
+      metadata_manager_->CreateChunkHandle(non_exist_file, 0));
+  EXPECT_EQ(non_exist_chunk_handle.status().error_code(),
+            google::protobuf::util::error::NOT_FOUND);
 
   auto non_exist_file2("/newFile/foo");
   auto non_exist_chunk_handle2(
-      metadataManager_->CreateChunkHandle(non_exist_file2, 0));
-  EXPECT_EQ(non_exist_chunk_handle2.status().error_message(),
-            "File metadata does not exist: /newFile/foo");
+           metadata_manager_->CreateChunkHandle(non_exist_file2, 0));
+  EXPECT_EQ(non_exist_chunk_handle2.status().error_code(),
+            google::protobuf::util::error::NOT_FOUND);
+}
+
+// Stress test for contentious creation of file metadata. We spawn
+// a number of threads, and each threads keeps trying to create
+// file metadata for /l0/l1/.../l{threadId}. So if done only once some
+// of these creation would fail because the parent directory may not
+// exist yet, but keep trying they should eventually succeed. Verify 
+// the file name at the end of this test
+TEST_F(MetadataManagerUnitTest, ConcurrentFileCreationStressTest) {
+  int num_of_threads(24);
+  std::vector<std::thread> threads;
+  std::string filename_base("l");
+
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string filename(ComputeNestedFileName(filename_base,i+1));
+      
+      auto create_file_metadata_status(
+               metadata_manager_->CreateFileMetadata(filename));
+     
+      // Retry if the above is not successful
+      while(!create_file_metadata_status.ok()) {
+        create_file_metadata_status = 
+            metadata_manager_->CreateFileMetadata(filename);
+      }
+    }));
+  }
+
+  JoinAndClearThreads(threads);
+
+  for (int i = 0; i < num_of_threads; i++) {
+    std::string filename(ComputeNestedFileName(filename_base,i+1));
+    // Construct the file name for each thread
+    EXPECT_TRUE(metadata_manager_->ExistFileMetadata(filename)); 
+  }
+}
+
+// Stress test for contentious creation of chunk handles. First we create
+// A series of nested files, i.e. /n0/n1/.../n{num_of_thread-1}.  
+// Each thread operates on a nested file, /n0/n1/.../n{thread_id},
+// and create a {num_of_chunk_per_file} number of chunks concurrent.
+// Verify that all assitned chunk handles are unique, and each file metadata
+// contains an expected number of chunk handles
+TEST_F(MetadataManagerUnitTest, ConcurrentFileChunkCreationStressTest) {
+  int num_of_threads(24);
+  int num_of_chunk_per_file(100);
+  gfs::common::thread_safe_flat_hash_set<std::string> assigned_chunk_handles;
+  std::vector<std::thread> threads;
+  std::string filename_base("n");
+
+  // Create nested files
+  int nested_level(num_of_threads);
+  for (int i = 0; i < nested_level; i++) {
+    std::string filename(ComputeNestedFileName(filename_base, i+1));
+    auto create_file_metadata_status(
+             metadata_manager_->CreateFileMetadata(filename));
+    EXPECT_TRUE(create_file_metadata_status.ok());
+  }
+
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string filename(ComputeNestedFileName(filename_base, i+1));
+      for (int chunk_id = 0; chunk_id < num_of_chunk_per_file; chunk_id++) {
+        auto create_chunk_handle_or(
+                 metadata_manager_->CreateChunkHandle(filename, chunk_id));
+        EXPECT_TRUE(create_chunk_handle_or.ok());
+        std::string chunk_handle(create_chunk_handle_or.ValueOrDie());
+        assigned_chunk_handles.insert(chunk_handle);
+      }
+    }));
+  }
+
+  JoinAndClearThreads(threads);
+
+  // Verify that there are num_of_chunk_per_file * num_of_threads number of 
+  // chunk handles assigned in this test
+  EXPECT_EQ(assigned_chunk_handles.size(), 
+            num_of_chunk_per_file * num_of_threads);
+
+  // Verify that each nested file has expected number of chunk handles
+  for (int i = 0; i < nested_level; i++) {
+    std::string filename(ComputeNestedFileName(filename_base, i+1));
+    
+    auto file_metadata_or(metadata_manager_->GetFileMetadata(filename));
+    EXPECT_TRUE(file_metadata_or.ok());
+    auto file_metadata(file_metadata_or.ValueOrDie());
+    EXPECT_EQ(file_metadata->chunk_handles_size(), num_of_chunk_per_file);
+  }
 }


### PR DESCRIPTION
In this PR, we use the parallel-hashmap library to manage concurrent access and updates to shared resources such as locking and file metadata. This reduces overhead of managing some of the lock resources ourselves and simplifies code. 

This PR also includes additional stress testing of the metadata manager, which includes:
1) contentious creation of chunk handles for the same file
2) concurrent creation of nested files
3) concurrent creation of chunk handles for nested files

Minor style fix is also included in this PR. 