### PR TITLE
[bug] make glog failure signal handler disabled by default, due to deadlock bug

### DIFF
--- a/src/common/system_logger.cc
+++ b/src/common/system_logger.cc
@@ -6,7 +6,8 @@ namespace common {
 
 // TODO(bmokutub): If needed, also configure minloglevel to filter out certain
 // log levels. And log to files too.
-void SystemLogger::Initialize(const std::string& program_name) {
+void SystemLogger::Initialize(const std::string& program_name,
+                              const bool use_failure_signal_handler) {
   if (this->is_initialized_) {
     // Already initialized. Should be done once.
     return;
@@ -17,9 +18,11 @@ void SystemLogger::Initialize(const std::string& program_name) {
 
   google::InitGoogleLogging(program_name.c_str());
 
-  // Enables us to dump useful information when the program crashes on certain
-  // signals such as SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGBUS, and SIGTERM.
-  google::InstallFailureSignalHandler();
+  if (use_failure_signal_handler) {
+    // Enables us to dump useful information when the program crashes on certain
+    // signals such as SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGBUS, and SIGTERM.
+    google::InstallFailureSignalHandler();
+  }
 
   this->is_initialized_ = true;
 }

--- a/src/common/system_logger.h
+++ b/src/common/system_logger.h
@@ -37,7 +37,21 @@ class SystemLogger {
   // configurations. Currently logging to console only. Must be called before
   // using any of the logging macros. This isn't thread safe and must be done
   // from a single thread.
-  void Initialize(const std::string& program_name);
+  //
+  // If |use_failure_signal_handler| is true, also install the
+  // "InstallFailureSignalHandler" provided by glog, which enables us to dump
+  // useful information when the program crashes on certain signals such as
+  // SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGBUS, and SIGTERM.
+  //
+  // However, the glibc built-in stack-unwinder on 64-bit systems has some
+  // problem with the glog libraries, and is known to cause terminal to hang
+  // and be in deadlock:
+  //    https://github.com/google/glog/blob/master/INSTALL#L15
+  // To solve this, you need to install libunwind first:
+  //    https://www.nongnu.org/libunwind/
+  // Note that it doesn't work with new MacOS systems yet.
+  void Initialize(const std::string& program_name,
+                  const bool use_failure_signal_handler = false);
 
  private:
   bool is_initialized_;


### PR DESCRIPTION
It doesn't work well with Linux and new MacOS, so disable it by default, and use an optional parameter to control it's activation status