### PR TITLE
[feat] - Master chunk server manager service v1

### DIFF
--- a/src/common/protocol_client/BUILD.bazel
+++ b/src/common/protocol_client/BUILD.bazel
@@ -12,3 +12,16 @@ cc_library(
         "@com_google_protobuf//:protobuf_lite",
     ],
 )
+
+cc_library(
+    name = "master_chunk_server_manager_service_client",
+    srcs = ["master_chunk_server_manager_service_client.cc"],
+    hdrs = ["master_chunk_server_manager_service_client.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/common:utils",
+        "//src/protos/grpc:cc_master_chunk_server_manager_service_grpc",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf_lite",
+    ],
+)

--- a/src/common/protocol_client/master_chunk_server_manager_service_client.cc
+++ b/src/common/protocol_client/master_chunk_server_manager_service_client.cc
@@ -20,7 +20,8 @@ MasterChunkServerManagerServiceClient::SendRequest(
     const ReportChunkServerRequest& request, ClientContext& context) {
   ReportChunkServerReply reply;
   grpc::Status status = stub_->ReportChunkServer(&context, request, &reply);
-
+  
+  // TODO(tugan): Replace this with ReturnStatusOrFromGrpcStatus.
   if (status.ok()) {
     return reply;
   } else {

--- a/src/common/protocol_client/master_chunk_server_manager_service_client.cc
+++ b/src/common/protocol_client/master_chunk_server_manager_service_client.cc
@@ -1,0 +1,39 @@
+#include "src/common/protocol_client/master_chunk_server_manager_service_client.h"
+
+#include <memory>
+
+#include "google/protobuf/stubs/status.h"
+#include "src/common/utils.h"
+
+using gfs::common::utils::ConvertGrpcStatusToProtobufStatus;
+using google::protobuf::util::Status;
+using google::protobuf::util::StatusOr;
+using grpc::ClientContext;
+using protos::grpc::ReportChunkServerReply;
+using protos::grpc::ReportChunkServerRequest;
+
+namespace gfs {
+namespace service {
+
+StatusOr<ReportChunkServerReply>
+MasterChunkServerManagerServiceClient::SendRequest(
+    const ReportChunkServerRequest& request, ClientContext& context) {
+  ReportChunkServerReply reply;
+  grpc::Status status = stub_->ReportChunkServer(&context, request, &reply);
+
+  if (status.ok()) {
+    return reply;
+  } else {
+    return ConvertGrpcStatusToProtobufStatus(status);
+  }
+}
+
+StatusOr<ReportChunkServerReply>
+MasterChunkServerManagerServiceClient::SendRequest(
+    const ReportChunkServerRequest& request) {
+  ClientContext default_context;
+  return SendRequest(request, default_context);
+}
+
+}  // namespace service
+}  // namespace gfs

--- a/src/common/protocol_client/master_chunk_server_manager_service_client.h
+++ b/src/common/protocol_client/master_chunk_server_manager_service_client.h
@@ -1,0 +1,82 @@
+#ifndef GFS_COMMON_PROTOCOL_CLIENT_MASTER_CHUNK_SERVER_MANAGER_SERVICE_CLIENT_H_
+#define GFS_COMMON_PROTOCOL_CLIENT_MASTER_CHUNK_SERVER_MANAGER_SERVICE_CLIENT_H_
+
+#include <memory>
+
+#include "google/protobuf/stubs/status.h"
+#include "google/protobuf/stubs/statusor.h"
+#include "grpcpp/grpcpp.h"
+#include "src/protos/grpc/master_chunk_server_manager_service.grpc.pb.h"
+
+namespace gfs {
+namespace service {
+
+// MasterChunkServerManagerServiceClient for sending gRPC requests to the master
+// server to report the chunkserver chunks to the master.
+//
+// Example:
+//
+//  grpc::Channel master_channel =
+//     grpc::CreateChannel("0.0.0.0:50051", grpc::InsecureChannelCredentials());
+//  MasterChunkServerManagerServiceClient client(master_channel);
+//
+//  ReportChunkServerRequest request;
+//  // Populate your requests here ...
+//
+//  grpc::ClientContext client_context;
+//
+//  // Add optional data to client context, if applicable
+//  client_context.set_deadline(std::chrono::system_clock::now() +
+//                  std::chrono::milliseconds(2000)); // optional deadline
+//  client_context.AddMetadata("foo", "bar"); // optional metadata
+//
+//  // Send the request and get the reply
+//  StatusOr<ReportChunkServerReply> status_or =
+//    client.SendRequest(request, client_context);
+//  if (status_or.ok()) {
+//    LOG(INFO) << status_or.ValueOrDie().DebugString() << std::endl;
+//  }
+class MasterChunkServerManagerServiceClient {
+ public:
+  // Initialize a protocol manager for talking to a gRPC server listening on
+  // the specified gRPC |channel|, which handles gRPCs defined in the
+  // MasterChunkServerManagerService.
+  MasterChunkServerManagerServiceClient(std::shared_ptr<grpc::Channel> channel)
+      : stub_(protos::grpc::MasterChunkServerManagerService::NewStub(channel)) {
+  }
+
+  // Send a ReportChunkServerRequest gRPC |request| to the master server, and
+  // return master's corresponding reply if successful; otherwise a Status with
+  // error message. This method is synchronous and will block until it hears
+  // from the master
+  // This chunkserver report call should be less frequent compared to the
+  // heartbeat call (which is used to see if the chunkserver is still running),
+  // due to the potential size of the messages. Since there can be a very large
+  // number of chunks on each chunkserver. Should be done on chunkserver
+  // startup/restart and then periodically after that.
+  //
+  // If you need to customize the gRPC behavior, such as sending extra metadata
+  // or set a timeout for the gRPC call, pass an extra gRPC |context| object.
+  // Otherwise, default client context is used. For more, see:
+  // https://github.com/grpc/grpc/blob/master/include/grpcpp/impl/codegen/client_context_impl.h
+  //
+  // Note that you should NOT reuse client context, as they are call-specific.
+  //
+  // TODO(bmokutub): support sending asynchronous client requests
+  google::protobuf::util::StatusOr<protos::grpc::ReportChunkServerReply>
+  SendRequest(const protos::grpc::ReportChunkServerRequest& request);
+
+  google::protobuf::util::StatusOr<protos::grpc::ReportChunkServerReply>
+  SendRequest(const protos::grpc::ReportChunkServerRequest& request,
+              grpc::ClientContext& context);
+
+ private:
+  // The gRPC client for managing protocols defined in
+  // MasterChunkServerManagerService.
+  std::unique_ptr<protos::grpc::MasterChunkServerManagerService::Stub> stub_;
+};
+
+}  // namespace service
+}  // namespace gfs
+
+#endif  // GFS_COMMON_PROTOCOL_CLIENT_MASTER_CHUNK_SERVER_MANAGER_SERVICE_CLIENT_H_

--- a/src/protos/chunk_server.proto
+++ b/src/protos/chunk_server.proto
@@ -14,3 +14,12 @@ message ChunkServer {
   // Amount of memory in megabytes available on the server
   uint32 available_memory_mb = 2;
 }
+
+// Information about a chunk on a chunkserver.
+// This shouldn't include the chunk data.
+// Can be renamed to something better later.
+message FileChunk {
+  string handle = 1;  
+  // The version of the chunk on the chunkserver.
+  uint32 version = 2;
+}

--- a/src/protos/grpc/BUILD.bazel
+++ b/src/protos/grpc/BUILD.bazel
@@ -71,3 +71,26 @@ cc_grpc_library(
     visibility = ["//visibility:public"],
     deps = [":cc_chunk_server_file_service_proto"],
 )
+
+proto_library(
+    name = "master_chunk_server_manager_service_proto",
+    srcs = ["master_chunk_server_manager_service.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/protos:chunk_server_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "cc_master_chunk_server_manager_service_proto",
+    visibility = ["//visibility:public"],
+    deps = [":master_chunk_server_manager_service_proto"],
+)
+
+cc_grpc_library(
+    name = "cc_master_chunk_server_manager_service_grpc",
+    srcs = [":master_chunk_server_manager_service_proto"],
+    grpc_only = True,
+    visibility = ["//visibility:public"],
+    deps = [":cc_master_chunk_server_manager_service_proto"],
+)

--- a/src/protos/grpc/master_chunk_server_manager_service.proto
+++ b/src/protos/grpc/master_chunk_server_manager_service.proto
@@ -31,15 +31,8 @@ message ReportChunkServerRequest {
   // The chunkserver making this request.
   protos.ChunkServer chunk_server = 1;
 
-  // Represents the reported chunk
-  message Chunk {
-    string handle = 1;  
-    // The version of the chunk that the chunkserver has.
-    uint32 version = 2;
-  }
-
   // All the chunks stored on the chunkserver.
-  repeated Chunk stored_chunks = 2;
+  repeated protos.FileChunk stored_chunks = 2;
 }
 
 message ReportChunkServerReply {

--- a/src/protos/grpc/master_chunk_server_manager_service.proto
+++ b/src/protos/grpc/master_chunk_server_manager_service.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package protos.grpc;
+
+import "src/protos/chunk_server.proto";
+
+// This is a service that runs on the master server that handles 
+// master coordination with chunk servers. This is different from the
+// heartbeat service which is used to send light messages to check the
+// health of the chunkserver.
+service MasterChunkServerManagerService {
+  // Each chunkserver periodically reports the chunks it has, 
+  // and the master replies with the identity of all chunks that are
+  // no longer present in the master’s metadata, as well as the reported 
+  // chunks with stale version. Chunkserver can have stale version for a chunk 
+  // if it crash and miss some mutations on the chunk. 
+  // Once the chunkserver receives the reply, it is free to delete its replicas
+  // of such chunks.
+  // The master also uses this to update itself on the location of each chunk.
+  // Chunkserver has the final word over what chunks it does or does not have on 
+  // its own disks. Because errors on a chunkserver may cause chunks to vanish 
+  // spontaneously.
+  // This chunkserver report call will be less frequent compared to the heartbeat
+  // call (which is used to see if the chunkserver is still running), due to the
+  // potential size of the messages. Since there can be a very large number of chunks
+  // on each chunkserver.
+  rpc ReportChunkServer(ReportChunkServerRequest) returns (ReportChunkServerReply) {}
+}
+
+message ReportChunkServerRequest {
+  // The chunkserver making this request.
+  protos.ChunkServer chunk_server = 1;
+
+  // Represents the reported chunk
+  message Chunk {
+    string handle = 1;  
+    // The version of the chunk that the chunkserver has.
+    uint32 version = 2;
+  }
+
+  // All the chunks stored on the chunkserver.
+  repeated Chunk stored_chunks = 2;
+}
+
+message ReportChunkServerReply {
+  // The original request associated with this reply.
+  ReportChunkServerRequest request = 1;
+
+  // The chunks reported by the chunkserver that the master considers to be stale.
+  // This allows the chunkserver to delete them.
+  repeated string stale_chunk_handles = 2;
+}

--- a/src/server/master_server/BUILD.bazel
+++ b/src/server/master_server/BUILD.bazel
@@ -53,6 +53,17 @@ cc_binary(
     srcs = ["run_master_server_main.cc"],
     deps = [
         ":master_metadata_service_impl",
+        ":master_chunk_server_manager_service_impl",
         "//src/common:system_logger",
+    ],
+)
+
+cc_library(
+    name = "master_chunk_server_manager_service_impl",
+    srcs = ["master_chunk_server_manager_service_impl.cc"],
+    hdrs = ["master_chunk_server_manager_service_impl.h"],
+    deps = [
+        "//src/protos/grpc:cc_master_chunk_server_manager_service_grpc",
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )

--- a/src/server/master_server/master_chunk_server_manager_service_impl.cc
+++ b/src/server/master_server/master_chunk_server_manager_service_impl.cc
@@ -1,0 +1,22 @@
+#include "src/server/master_server/master_chunk_server_manager_service_impl.h"
+
+#include "grpcpp/grpcpp.h"
+#include "src/protos/grpc/master_chunk_server_manager_service.grpc.pb.h"
+
+using grpc::ServerContext;
+using protos::grpc::ReportChunkServerReply;
+using protos::grpc::ReportChunkServerRequest;
+
+namespace gfs {
+namespace service {
+
+grpc::Status MasterChunkServerManagerServiceImpl::ReportChunkServer(
+    ServerContext* context, const ReportChunkServerRequest* request,
+    ReportChunkServerReply* reply) {
+  // TODO(bmokutub): handle the request by using the ChunkServerManager for
+  // updating chunk/chunkserver map and metadata manager to check chunk latest
+  // version.
+  return grpc::Status::OK;
+}
+}  // namespace service
+}  // namespace gfs

--- a/src/server/master_server/master_chunk_server_manager_service_impl.h
+++ b/src/server/master_server/master_chunk_server_manager_service_impl.h
@@ -1,0 +1,30 @@
+#ifndef GFS_SERVER_MASTER_SERVER_MASTER_CHUNK_SERVER_MANAGER_SERVICE_IMPL_H_
+#define GFS_SERVER_MASTER_SERVER_MASTER_CHUNK_SERVER_MANAGER_SERVICE_IMPL_H_
+
+#include "grpcpp/grpcpp.h"
+#include "src/protos/grpc/master_chunk_server_manager_service.grpc.pb.h"
+
+namespace gfs {
+namespace service {
+
+// The synchronous implementation for handling MasterChunkServerManagerService
+// requests.
+class MasterChunkServerManagerServiceImpl final
+    : public protos::grpc::MasterChunkServerManagerService::Service {
+  // Handles a ReportChunkServerRequest sent by a chunkserver.
+  grpc::Status ReportChunkServer(
+      grpc::ServerContext* context,
+      const protos::grpc::ReportChunkServerRequest* request,
+      protos::grpc::ReportChunkServerReply* reply) override;
+};
+
+// The asynchronous implementation for handling MasterChunkServerManagerService
+// requests
+// TODO(bmokutub): support handling client requests asynchronously
+class MasterChunkServerManagerServiceAsyncImpl final
+    : public protos::grpc::MasterChunkServerManagerService::Service {};
+
+}  // namespace service
+}  // namespace gfs
+
+#endif  // GFS_SERVER_MASTER_SERVER_MASTER_CHUNK_SERVER_MANAGER_SERVICE_IMPL_H_

--- a/src/server/master_server/run_master_server_main.cc
+++ b/src/server/master_server/run_master_server_main.cc
@@ -4,8 +4,10 @@
 #include "grpcpp/grpcpp.h"
 #include "src/common/system_logger.h"
 #include "src/server/master_server/master_metadata_service_impl.h"
+#include "src/server/master_server/master_chunk_server_manager_service_impl.h"
 
 using gfs::service::MasterMetadataServiceImpl;
+using gfs::service::MasterChunkServerManagerServiceImpl;
 using grpc::Server;
 using grpc::ServerBuilder;
 
@@ -26,6 +28,10 @@ int main(int argc, char** argv) {
   // Register a synchronous service for handling clients' metadata requests
   MasterMetadataServiceImpl metadata_service;
   builder.RegisterService(&metadata_service);
+
+  // Register a synchronous service for coordinating with chunkservers
+  MasterChunkServerManagerServiceImpl chunk_server_mgr_service;
+  builder.RegisterService(&chunk_server_mgr_service);
 
   // Assemble and start the server
   std::unique_ptr<Server> server(builder.BuildAndStart());


### PR DESCRIPTION
Chunk server manager service for coordinating with chunk servers and to allow chunk servers report their chunks.
changes:
1. service proto definition
2. service and client implementation. Server side still needs to finish implementation.
3. Add service master startup code
We don't have service tests for now.