### PR TITLE
[feat] - File chunk manager

### DIFF
--- a/src/protos/chunk_server.proto
+++ b/src/protos/chunk_server.proto
@@ -24,9 +24,16 @@ message ChunkServer {
 // Information about a chunk on a chunkserver.
 // This shouldn't include the chunk data.
 // Can be renamed to something better later.
-message FileChunk {
+message FileChunkOld { // remove??
   string handle = 1;
 
   // The version of the chunk on the chunkserver.
   uint32 version = 2;
+}
+
+message FileChunk {
+  // The version of the chunk.
+  uint32 version = 1;
+
+  bytes data = 2;
 }

--- a/src/protos/chunk_server.proto
+++ b/src/protos/chunk_server.proto
@@ -21,19 +21,12 @@ message ChunkServer {
   repeated string stored_chunk_handles = 3;
 }
 
-// Information about a chunk on a chunkserver.
-// This shouldn't include the chunk data.
-// Can be renamed to something better later.
-message FileChunkOld { // remove??
-  string handle = 1;
-
-  // The version of the chunk on the chunkserver.
-  uint32 version = 2;
-}
-
+// The file chunk. Used for serializing/deserializing 
+// the data to/from binary for disk storage.
 message FileChunk {
   // The version of the chunk.
   uint32 version = 1;
 
+  // The actual data for the chunk.
   bytes data = 2;
 }

--- a/src/protos/grpc/BUILD.bazel
+++ b/src/protos/grpc/BUILD.bazel
@@ -79,6 +79,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/protos:chunk_server_proto",
+        "//src/protos:metadata_proto",
     ],
 )
 

--- a/src/protos/grpc/master_chunk_server_manager_service.proto
+++ b/src/protos/grpc/master_chunk_server_manager_service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package protos.grpc;
 
 import "src/protos/chunk_server.proto";
+import "src/protos/metadata.proto";
 
 // This is a service that runs on the master server that handles 
 // master coordination with chunk servers. This is different from the
@@ -37,7 +38,7 @@ message ReportChunkServerRequest {
   protos.ChunkServer chunk_server = 1;
 
   // All the chunks stored on the chunkserver.
-  repeated protos.FileChunk stored_chunks = 2;
+  repeated protos.FileChunkMetadata stored_chunks = 2;
 }
 
 message ReportChunkServerReply {

--- a/src/server/chunk_server/BUILD.bazel
+++ b/src/server/chunk_server/BUILD.bazel
@@ -51,6 +51,7 @@ cc_binary(
     deps = [
         ":chunk_server_file_service_impl",
         ":chunk_server_lease_service_impl",
+        ":file_chunk_manager",
         "//src/common:config_manager",
         "//src/common:system_logger",
         "@com_google_absl//absl/flags:flag",

--- a/src/server/chunk_server/BUILD.bazel
+++ b/src/server/chunk_server/BUILD.bazel
@@ -30,6 +30,20 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "file_chunk_manager",
+    srcs = ["file_chunk_manager.cc"],
+    hdrs = ["file_chunk_manager.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/protos:cc_chunk_server_proto",
+        "//src/protos:cc_metadata_proto",
+        "//src/common:system_logger",
+        "@com_google_leveldb//:leveldb",
+        "@com_github_grpc_grpc//:grpc++",
+    ],
+)
+
 cc_binary(
     name = "run_chunk_server_main",
     srcs = ["run_chunk_server_main.cc"],

--- a/src/server/chunk_server/file_chunk_manager.cc
+++ b/src/server/chunk_server/file_chunk_manager.cc
@@ -1,0 +1,301 @@
+#include "src/server/chunk_server/file_chunk_manager.h"
+
+#include <memory>
+#include <string>
+
+#include "leveldb/write_batch.h"
+#include "src/common/system_logger.h"
+
+namespace gfs {
+
+namespace server {
+
+FileChunkManager::FileChunkManager()
+    : chunk_database_(nullptr), max_chunk_size_bytes_(0) {}
+
+FileChunkManager* FileChunkManager::GetInstance() {
+  static FileChunkManager instance;
+
+  return &instance;
+}
+
+void FileChunkManager::Initialize(const std::string& chunk_database_name,
+                                  const uint32_t& max_chunk_size_bytes) {
+  // Currently using the default configs for leveldb. We can tune configuration
+  // if we see that it isn't efficient enough to meet our needs. By default 4kb
+  // (uncompressed bytes) blocks and compression is enabled. Check_sum
+  // verification isn't enabled by default. Can add more configs here later.
+
+  leveldb::DB* database;
+
+  leveldb::Options options;
+  options.create_if_missing = true;
+
+  leveldb::Status status =
+      leveldb::DB::Open(options, chunk_database_name, &database);
+
+  LOG_ASSERT(status.ok());
+
+  // Database is closed once pointer is deleted.
+  this->chunk_database_ = std::unique_ptr<leveldb::DB>(database);
+  this->max_chunk_size_bytes_ = max_chunk_size_bytes;
+}
+
+uint32_t FileChunkManager::GetMaxChunkSizeBytes() const {
+  return this->max_chunk_size_bytes_;
+}
+
+google::protobuf::util::Status FileChunkManager::CreateChunk(
+    const std::string& chunk_handle, const uint32_t& create_version) {
+  // Allocates new iterator from heap. Using iterator instead of getting to
+  // avoid copying because we don't need the data, just needs to see if handle
+  // already exist.
+  std::unique_ptr<leveldb::Iterator> db_read_iterator(
+      chunk_database_->NewIterator(leveldb::ReadOptions()));
+
+  db_read_iterator->Seek(chunk_handle);
+
+  // If iterator is valid (points to a chunk), and no error was encountered and
+  // the pointed chunk has the same handle. Checking handle even after validity,
+  // because it can point to another chunk after seek, if chunk_handle isn't
+  // found.
+  if (db_read_iterator->Valid() && db_read_iterator->status().ok() &&
+      db_read_iterator->key() == chunk_handle) {
+    // already exist
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::ALREADY_EXISTS,
+        "Chunk already exist with the specified handle. Found handle=" +
+            db_read_iterator->key().ToString());
+  }
+
+  // Assuming no concurrent create operation for the same handle. Since it's
+  // prevented by master. So no time-of-check to time-of-use condition here.
+
+  // Doesn't exist, let us create it with no data.
+  protos::FileChunk new_chunk;
+  new_chunk.set_version(create_version);
+
+  leveldb::WriteOptions write_options;
+  // Synchronous at the moment, and returns when update is applied to disk. This
+  // isn't the best, but we can improve this and do asynchronous writes, by
+  // using a Write Ahead Log (WAL) to maintain durability.
+  write_options.sync = true;
+
+  leveldb::Status status = this->chunk_database_->Put(
+      write_options, chunk_handle, new_chunk.SerializeAsString());
+
+  if (!status.ok()) {
+    // write failed
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::UNKNOWN,
+        "Failed creating new chunk. Status: " + status.ToString());
+  }
+
+  return google::protobuf::util::Status::OK;
+}
+
+google::protobuf::util::StatusOr<std::string> FileChunkManager::ReadFromChunk(
+    const std::string& chunk_handle, const uint32_t& read_version,
+    const uint32_t& start_offset, const uint32_t& length) {
+  auto result = GetFileChunk(chunk_handle, read_version);
+
+  if (!result.ok()) {
+    // Read failed
+    return result.status();
+  }
+
+  auto file_chunk = result.ValueOrDie();
+
+  // Check that we aren't trying to read data that isn't there
+  if (start_offset > file_chunk->data().length()) {
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::OUT_OF_RANGE,
+        "Read start offset is after end of chunk. End of chunk (bytes): " +
+            file_chunk->data().length());
+  }
+
+  // This may return less than length, if chunk doesn't have up to that.
+  return file_chunk->data().substr(start_offset, length);
+}
+
+google::protobuf::util::StatusOr<uint32_t> FileChunkManager::WriteToChunk(
+    const std::string& chunk_handle, const uint32_t& write_version,
+    const uint32_t& start_offset, const uint32_t& length,
+    const std::string& new_data) {
+  auto result = GetFileChunk(chunk_handle, write_version);
+
+  if (!result.ok()) {
+    // Read failed
+    return result.status();
+  }
+
+  auto file_chunk = result.ValueOrDie();
+
+  // Update the fetched data
+
+  // Write must start from an existing offset or current end of chunk.
+  if (start_offset > file_chunk->data().length()) {
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::OUT_OF_RANGE,
+        "Write start offset is after end of chunk. End of chunk (bytes): " +
+            file_chunk->data().length());
+  }
+
+  // Can write past the current length but not more than max chunk size.
+  uint32_t remaining_bytes = this->max_chunk_size_bytes_ - start_offset;
+
+  if (remaining_bytes == 0) {
+    // Chunk is full, can't write
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::OUT_OF_RANGE,
+        "Chunk is full. Max chunk size (bytes): " +
+            this->max_chunk_size_bytes_);
+  }
+
+  // Don't want to write more than the bytes left for the chunk to be full.
+  uint32_t actual_write_length = std::min(length, remaining_bytes);
+
+  // Writes to the same chunk are serialized (no concurrent writes to the same
+  // chunk), so no race condition here.
+
+  // write to the existing data in memory
+  file_chunk->mutable_data()->replace(
+      start_offset, actual_write_length, new_data.data(),
+      /*start_position_in_new_data=*/0, actual_write_length);
+
+  leveldb::WriteOptions write_options;
+  // Synchronous at the moment, and returns when update is applied to disk. This
+  // isn't the best, but we can improve this and do asynchronous writes, by
+  // using a Write Ahead Log (WAL) to maintain durability.
+  write_options.sync = true;
+
+  leveldb::Status status = this->chunk_database_->Put(
+      write_options, chunk_handle, file_chunk->SerializeAsString());
+
+  if (!status.ok()) {
+    // write failed
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::UNKNOWN,
+        "Failed while writing data. Status: " + status.ToString());
+  }
+
+  return actual_write_length;
+}
+
+google::protobuf::util::Status FileChunkManager::UpdateChunkVersion(
+    const std::string& chunk_handle, const uint32_t& from_version,
+    const uint32_t& to_version) {
+  auto result = GetFileChunk(chunk_handle, from_version);
+
+  if (!result.ok()) {
+    // Read failed
+    return result.status();
+  }
+
+  auto file_chunk = result.ValueOrDie();
+
+  // Update the version, since we found the chunk with the from_version
+  file_chunk->set_version(to_version);
+
+  leveldb::WriteOptions write_options;
+  // Synchronous at the moment, and returns when update is applied to disk. This
+  // isn't the best, but we can improve this and do asynchronous writes, by
+  // using a Write Ahead Log (WAL) to maintain durability.
+  write_options.sync = true;
+
+  leveldb::Status status = this->chunk_database_->Put(
+      write_options, chunk_handle, file_chunk->SerializeAsString());
+
+  if (!status.ok()) {
+    // version update failed
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::UNKNOWN,
+        "Failed while updating version. Status: " + status.ToString());
+  }
+
+  return google::protobuf::util::Status::OK;
+}
+
+google::protobuf::util::StatusOr<uint32_t> FileChunkManager::AppendToChunk(
+    const std::string& chunk_handle, const uint32_t& append_version,
+    const uint32_t& length, const std::string& new_data) {
+  return google::protobuf::util::Status(
+      google::protobuf::util::error::UNIMPLEMENTED,
+      "Append not implemented yet.");
+}
+
+google::protobuf::util::StatusOr<std::shared_ptr<protos::FileChunk>>
+FileChunkManager::GetFileChunk(const std::string& chunk_handle,
+                               const uint32_t& version) {
+  std::string existing_data;
+  leveldb::Status status = this->chunk_database_->Get(
+      leveldb::ReadOptions(), chunk_handle, &existing_data);
+
+  if (!status.ok()) {
+    // chunk handle not found
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::NOT_FOUND,
+        "Chunk not found. Handle=" + chunk_handle +
+            " Status: " + status.ToString());
+  }
+
+  std::shared_ptr<protos::FileChunk> file_chunk(new protos::FileChunk());
+
+  if (!file_chunk->ParseFromString(existing_data)) {
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::INTERNAL,
+        "Failed to parse data from disk.");
+  }
+
+  // check version
+  if (file_chunk->version() != version) {
+    // wrong version
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::NOT_FOUND,
+        "Specified version doesn't match current version. Specified=" +
+            std::to_string(version) +
+            " Current=" + std::to_string(file_chunk->version()));
+  }
+
+  return file_chunk;
+}
+
+google::protobuf::util::Status FileChunkManager::DeleteChunk(
+    const std::string& chunk_handle) {
+  leveldb::Status status =
+      this->chunk_database_->Delete(leveldb::WriteOptions(), chunk_handle);
+
+  if (!status.ok()) {
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::UNKNOWN,
+        "Deletion failed. Status: " + status.ToString());
+  }
+
+  return google::protobuf::util::Status::OK;
+}
+
+std::list<protos::FileChunkMetadata>
+FileChunkManager::GetAllFileChunkMetadata() {
+  std::unique_ptr<leveldb::Iterator> iterator(
+      this->chunk_database_->NewIterator(leveldb::ReadOptions()));
+
+  std::list<protos::FileChunkMetadata> metadatas;
+
+  // Iterate the entire database for chunks
+  for (iterator->SeekToFirst(); iterator->Valid(); iterator->Next()) {
+    protos::FileChunk file_chunk;
+
+    if (file_chunk.ParseFromString(iterator->value().ToString())) {
+      protos::FileChunkMetadata metadata;
+      metadata.set_chunk_handle(iterator->key().ToString());
+      metadata.set_version(file_chunk.version());
+
+      metadatas.push_back(metadata);
+    }
+  }
+
+  return metadatas;
+}
+
+}  // namespace server
+}  // namespace gfs

--- a/src/server/chunk_server/file_chunk_manager.h
+++ b/src/server/chunk_server/file_chunk_manager.h
@@ -1,0 +1,208 @@
+#ifndef GFS_SERVER_CHUNK_SERVER_FILE_CHUNK_MANAGER_H_
+#define GFS_SERVER_CHUNK_SERVER_FILE_CHUNK_MANAGER_H_
+
+#include <list>
+#include <memory>
+#include <string>
+
+#include "google/protobuf/stubs/statusor.h"
+#include "leveldb/db.h"
+#include "src/protos/chunk_server.pb.h"
+#include "src/protos/metadata.pb.h"
+
+namespace gfs {
+
+namespace server {
+
+// Singleton class responsible for storing and retrieving file chunks.
+// The max size of the chunk is configurable during initialization, and
+// chunks are identified using their chunk_handle as the key. This also
+// supports external data versioning where clients set the version of data.
+// File chunks are serialized to binary and stored on disk. We use std::string
+// for passing the data but the data doesn't have to be string type. We just
+// use std::string to represent the data bytes and treat it as bytes, regardless
+// of the actual data type.
+//
+// Uses an internal database (leveldb) as the underlying storage system.
+// Since the underlying database is abstracted, we can change it while still
+// maintaining the interfaces we provide to the class clients.
+// Using a database like leveldb, we are able to handoff concurrency safety to
+// it, without having to handle it externally.
+// Leveldb is very configurable and currently using some of the default
+// configurations which includes 4Kb block size, compression etc. We can tune
+// this for improve our performance if we see that it doesn't work well for us.
+//
+// We don't maintain any cache and rely on the system buffer cache, since we
+// write to disk.
+//
+// Note - All operations are synchronous at the moment, and returns when update
+// is applied to disk. This isn't the best, but we can improve this and do
+// asynchronous writes, by using a Write Ahead Log (WAL) to maintain durability.
+//
+// Usage (please see the method declaration for more info):
+// The file chunk manager needs to be initialize only once and before any chunk
+// operation is called.
+//
+// Initialization:
+// Note - The specified database_name can only be accessed by one file
+// chunk manager (process) at a time, and locks it to itself.
+//
+//    auto file_chunk_mgr = FileChunkManager::GetInstance();
+//    file_chunk_mgr->Initialize(
+//        /*chunk_database_name=*/"/tmp/file_chunk_mgr_test_db",
+//        /*max_chunk_size_bytes=*/100);
+//
+// New empty chunk creation: auto result =
+// file_chunk_mgr->CreateChunk("chunk_handle",
+// /*create_version=*/1);
+//
+// Update the chunk version: auto result =
+// file_chunk_mgr->UpdateChunkVersion("chunk_handle",
+// /*from_version=*/1, /*to_version=*/2);
+//
+// Write data for a specific version:
+// auto result = file_chunk_mgr->WriteToChunk("chunk_handle",
+// /*write_version=*/2,
+// /*start_offset=*/0, /*length=*/10, /*data=*/"data data data ");
+//
+// Read data for a specific version: auto result =
+// file_chunk_mgr->ReadFromChunk(
+//      "chunk_handle", /*read_version=*/2, /*start_offset=*/2, /*length=*/4);
+//
+// Delete a chunk: auto result = file_chunk_mgr->DeleteChunk("chunk_handle");
+//
+// Append to chunk: Not yet supported
+//
+// Get the metadata (handle, version) of all stored chunk. Useful when reporting
+// stored chunks to master: auto all_chunks =
+// file_chunk_mgr->GetAllFileChunkMetadata();
+//
+class FileChunkManager {
+ public:
+  // The singleton instance of the file chunk manager.
+  static FileChunkManager* GetInstance();
+
+  // To prevent copying the file chunk manager. Pointer copy is allowed.
+  FileChunkManager(const FileChunkManager&) = delete;
+
+  void operator=(const FileChunkManager&) = delete;
+
+  // The file chunk manager must be initialized only once for a process, before
+  // any chunk operation is perfomed. This does the setup for the internal
+  // database needed by the manager. The database name (path plus name e.g.
+  // /tmp/mydb) passed can be an existing chunk database, or name for a new one
+  // to be created.
+  // The specified database_name can only be accessed by one file
+  // chunk manager (process) at a time, and locks it to itself. You can't use
+  // the same database name for different processes (each with a file chunk
+  // manager) on the same machine. You can also set the max size for each chunk.
+  // Once this size is met, the chunk is considered to be full and can't grow
+  // pass that. Writes that will make it larger will be truncated.
+  void Initialize(const std::string& chunk_database_name,
+                  const uint32_t& max_chunk_size_bytes);
+
+  // Returns the configured max size of a chunk in bytes.
+  uint32_t GetMaxChunkSizeBytes() const;
+
+  // Returns the metadata (chunk_handle and version) for all chunks stored by
+  // the file chunk manager. If a chunk data is corrupted, it won't return it.
+  // This is useful for reporting the chunks stored on a chunk server. Returns
+  // an empty list if none is stored.
+  std::list<protos::FileChunkMetadata> GetAllFileChunkMetadata();
+
+  // Create a new empty chunk with the specified create_version. Not intializing
+  // the create_version because the file chunk mgr allows versioning to be
+  // managed externally. Fails if a chunk with the specified handle already
+  // exists.
+  google::protobuf::util::Status CreateChunk(const std::string& chunk_handle,
+                                             const uint32_t& create_version);
+
+  // Reads data of the specified length from a chunk with the specified handle
+  // with the specified version, from the start_offset. Returns the data read if
+  // successful.
+  //
+  // Fails (Error: NOT_FOUND), if a chunk with the specified handle isn't found
+  // or if the specified read_version doesn't match the version of the stored
+  // chunk. Fails (Error: INTERNAL), if it is unable to deserialize the binary
+  // data from disk. Fails (Error: OUT_OF_RANGE), if the start_offset is greater
+  // than the offset of the end of the chunk.
+  google::protobuf::util::StatusOr<std::string> ReadFromChunk(
+      const std::string& chunk_handle, const uint32_t& read_version,
+      const uint32_t& start_offset, const uint32_t& length);
+
+  // Writes the specified data of the specified length to a chunk with the
+  // specified handle with the specified version, from the start_offset. Returns
+  // the actual length of data written if successful. The length of the data
+  // written can be smaller than specified length, if the chunk max size was
+  // reached.
+  //
+  // Fails (Error: NOT_FOUND), if a chunk with the specified handle isn't found
+  // or if the specified write_version doesn't match the version of the stored
+  // chunk.
+  // Fails (Error: INTERNAL), if it is unable to deserialize the binary
+  // data from disk for update.
+  // Fails (Error: OUT_OF_RANGE), if the start_offset is greater than the offset
+  // of the end of the chunk.
+  // Fails (Error: UNKNOWN), if writing the update to disk failed.
+  google::protobuf::util::StatusOr<uint32_t> WriteToChunk(
+      const std::string& chunk_handle, const uint32_t& write_version,
+      const uint32_t& start_offset, const uint32_t& length,
+      const std::string& new_data);
+
+  // Writes a new version to a chunk with the specified handle with the
+  // specified from_version. Returns successful, if the chunk has been updated
+  // to the to_version.
+  //
+  // Fails (Error: NOT_FOUND), if a chunk with the specified handle isn't found
+  // or if the specified from_version doesn't match the version of the stored
+  // chunk.
+  // Fails (Error: INTERNAL), if it is unable to deserialize the binary
+  // data from disk for update.
+  // Fails (Error: UNKNOWN), if writing the update to disk failed.
+  google::protobuf::util::Status UpdateChunkVersion(
+      const std::string& chunk_handle, const uint32_t& from_version,
+      const uint32_t& to_version);
+
+  // Not yet implemented.
+  // Append the specified data of the specified length to the end of the chunk
+  // with the specified handle with the specified version. Returns the actual
+  // length of data appended if successful. The length of the data appended can
+  // be smaller than specified length, if the chunk max size was reached.
+  google::protobuf::util::StatusOr<uint32_t> AppendToChunk(
+      const std::string& chunk_handle, const uint32_t& append_version,
+      const uint32_t& length, const std::string& new_data);
+
+  // Delete the chunk with the specified handle from the chunk database. Returns
+  // successfully, if chunk has been deleted.
+  // Fails (Error: UNKNOWN), if deletion, failed. Could be the chunk with
+  // specified handle doesn't exist.
+  google::protobuf::util::Status DeleteChunk(const std::string& chunk_handle);
+
+ private:
+  // Helper used by couple of the public interfaces to get a file chunk from
+  // database for a specific version. Returns the file chunk if successful.
+  // Fails (Error: NOT_FOUND), if a chunk with the specified handle isn't found
+  // or if the specified version doesn't match the version of the stored
+  // chunk.
+  // Fails (Error: INTERNAL), if it is unable to deserialize the binary
+  // data from disk.
+  google::protobuf::util::StatusOr<std::shared_ptr<protos::FileChunk>>
+  GetFileChunk(const std::string& chunk_handle, const uint32_t& version);
+
+  // The leveldb database used internally for chunk storage.
+  // Since the underlying database is abstracted, we can change it while still
+  // maintaining the interfaces we provide to the class clients.
+  // Using a database like leveldb, we are able to handoff concurrency safety to
+  // it, without having to handle it externally. Database is closed once pointer
+  // is deleted.
+  std::unique_ptr<leveldb::DB> chunk_database_;
+
+  // Configured max size of a chunk in bytes.
+  uint32_t max_chunk_size_bytes_;
+
+  FileChunkManager();
+};
+}  // namespace server
+}  // namespace gfs
+
+#endif  // GFS_SERVER_CHUNK_SERVER_FILE_CHUNK_MANAGER_H_

--- a/src/server/chunk_server/run_chunk_server_main.cc
+++ b/src/server/chunk_server/run_chunk_server_main.cc
@@ -8,8 +8,10 @@
 #include "src/common/system_logger.h"
 #include "src/server/chunk_server/chunk_server_file_service_impl.h"
 #include "src/server/chunk_server/chunk_server_lease_service_impl.h"
+#include "src/server/chunk_server/file_chunk_manager.h"
 
 using gfs::common::ConfigManager;
+using gfs::server::FileChunkManager;
 using gfs::service::ChunkServerFileServiceImpl;
 using gfs::service::ChunkServerLeaseServiceImpl;
 using grpc::Server;
@@ -39,11 +41,21 @@ int main(int argc, char** argv) {
 
   LOG(INFO) << "Running as chunk server: " << chunk_server_name;
   LOG(INFO) << "Server starting...";
+
+  // Initialize the file chunk manager
+  // TODO(bmokutub): Pass the chunk_database_name as part of config mgr.
+  auto chunk_database_name = "/tmp/" + chunk_server_name + "db";
+  auto max_chunk_size_bytes = config->GetFileChunkBlockSize() * 1024 * 1024;
+  FileChunkManager::GetInstance()->Initialize(chunk_database_name,
+                                              max_chunk_size_bytes);
+  LOG(INFO) << "File chunk manager initialized with chunk database: "
+            << chunk_database_name;
+
   ServerBuilder builder;
 
   std::string server_address(
       config->GetServerAddress(chunk_server_name, resolve_hostname));
-  
+
   // Listen on the given address without any authentication mechanism for now.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
 

--- a/tests/server/chunk_server/BUILD.bazel
+++ b/tests/server/chunk_server/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "file_chunk_manager_test",
+    srcs = ["file_chunk_manager_test.cc"],
+    deps = [
+        #"//src/protos:cc_chunk_server_proto",
+        "//src/server/chunk_server:file_chunk_manager",
+        #"//tests:utils",
+        "@com_google_test//:gtest_main",
+        "@com_google_absl//absl/container:flat_hash_set",
+    ],
+)

--- a/tests/server/chunk_server/BUILD.bazel
+++ b/tests/server/chunk_server/BUILD.bazel
@@ -4,9 +4,7 @@ cc_test(
     name = "file_chunk_manager_test",
     srcs = ["file_chunk_manager_test.cc"],
     deps = [
-        #"//src/protos:cc_chunk_server_proto",
         "//src/server/chunk_server:file_chunk_manager",
-        #"//tests:utils",
         "@com_google_test//:gtest_main",
         "@com_google_absl//absl/container:flat_hash_set",
     ],

--- a/tests/server/chunk_server/file_chunk_manager_test.cc
+++ b/tests/server/chunk_server/file_chunk_manager_test.cc
@@ -1,0 +1,123 @@
+#include "src/server/chunk_server/file_chunk_manager.h"
+
+#include <future>
+#include <iostream>  //remove??
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "gtest/gtest.h"
+
+using namespace gfs::server;
+
+// The fixture for testing ChunkServerManager. Handles setup and cleanup for the
+// test methods.
+class FileChunkManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    file_chunk_mgr = FileChunkManager::GetInstance();
+    file_chunk_mgr->Initialize(
+        /*chunk_database_name=*/"/tmp/file_chunk_mgr_test_db",
+        /*max_chunk_size_bytes=*/100);
+  }
+
+  FileChunkManager* file_chunk_mgr;
+};
+
+// Test registering a chunk server with no chunks. Happens when a new
+// chunkserver is being registered.
+TEST_F(FileChunkManagerTest, BasicCrudOperationTest) {
+  std::string data = "Testing the filechunkmanager.";
+  std::string handle = "BasicCrudOperationTest";
+
+  uint32_t version = 1;
+  EXPECT_TRUE(file_chunk_mgr->CreateChunk(handle, version).ok());
+
+  // bump version before write
+  EXPECT_TRUE(
+      file_chunk_mgr->UpdateChunkVersion(handle, version, ++version).ok());
+
+  auto write_result =
+      file_chunk_mgr->WriteToChunk(handle, version, 0, data.size(), data);
+
+  EXPECT_TRUE(write_result.ok());
+
+  EXPECT_EQ(data.size(), write_result.ValueOrDie());
+
+  const uint32_t read_start_offset = 5;
+  const uint32_t read_length = 7;
+  auto read_result = file_chunk_mgr->ReadFromChunk(
+      handle, version, read_start_offset, read_length);
+
+  EXPECT_TRUE(read_result.ok());
+
+  EXPECT_EQ(data.substr(read_start_offset, read_length),
+            read_result.ValueOrDie());
+
+  EXPECT_TRUE(
+      file_chunk_mgr->UpdateChunkVersion(handle, version, ++version).ok());
+
+  const uint32_t update_offset = 10;
+  const std::string update_data = " Updating the previous write.";
+  auto update_result = file_chunk_mgr->WriteToChunk(
+      handle, version, update_offset, update_data.size(), update_data);
+
+  EXPECT_TRUE(update_result.ok());
+
+  EXPECT_EQ(update_data.size(), update_result.ValueOrDie());
+
+  auto update_read_result = file_chunk_mgr->ReadFromChunk(
+      handle, version, update_offset, update_data.size());
+
+  EXPECT_TRUE(update_read_result.ok());
+
+  EXPECT_EQ(update_data, update_read_result.ValueOrDie());
+
+  EXPECT_TRUE(file_chunk_mgr->DeleteChunk(handle).ok());
+
+  EXPECT_FALSE(
+      file_chunk_mgr
+          ->ReadFromChunk(handle, version, update_offset, update_data.size())
+          .ok());
+}
+
+// Test registering a chunk server with no chunks. Happens when a new
+// chunkserver is being registered.
+TEST_F(FileChunkManagerTest, GetAllFileChunkMetadata) {
+  const std::string data = "Testing the filechunkmanager.";
+  const std::string handle_prefix = "GetAllFileChunkMetadata";
+  const uint32_t chunk_count = 10;
+
+  absl::flat_hash_set<std::string> chunk_handles;
+
+  for (uint32_t chunk_id = 0; chunk_id < chunk_count; ++chunk_id) {
+    uint32_t version = 1;
+    auto handle = handle_prefix + std::to_string(chunk_id);
+    EXPECT_TRUE(file_chunk_mgr->CreateChunk(handle, version).ok());
+
+    EXPECT_TRUE(
+        file_chunk_mgr->UpdateChunkVersion(handle, version, ++version).ok());
+
+    auto write_result =
+        file_chunk_mgr->WriteToChunk(handle, version, 0, data.size(), data);
+
+    EXPECT_TRUE(write_result.ok());
+
+    EXPECT_EQ(data.size(), write_result.ValueOrDie());
+
+    chunk_handles.insert(handle);
+  }
+
+  auto all_chunks = file_chunk_mgr->GetAllFileChunkMetadata();
+
+  EXPECT_EQ(chunk_count, all_chunks.size());
+
+  for (auto iterator = all_chunks.begin(); iterator != all_chunks.end();
+       ++iterator) {
+    // Remove to show that we've seen this handle.
+    // If we removed nothing, means that we didn't create the handle or
+    // handle was stored more than once in file chunk mgr.
+    EXPECT_TRUE(chunk_handles.erase(iterator->chunk_handle()));
+  }
+}

--- a/tests/server/chunk_server/file_chunk_manager_test.cc
+++ b/tests/server/chunk_server/file_chunk_manager_test.cc
@@ -7,7 +7,7 @@
 
 using namespace gfs::server;
 
-// The fixture for testing ChunkServerManager. Handles setup and cleanup for the
+// The fixture for testing FileChunkManager. Handles setup and cleanup for the
 // test methods.
 class FileChunkManagerTest : public ::testing::Test {
  protected:


### PR DESCRIPTION
File chunk manager for storing and retrieving chunks using leveldb as underlying storage. Supports the following operations (please see file_chunk_manager.h for more info):
1. CreateChunk
2. UpdateChunkVersion
3. GetChunkVersion
4. ReadFromChunk
5. WriteToChunk
6. DeleteChunk
7. GetAllChunksMetadata

Added some basic CRUD tests. Will add more later.