### PR TITLE
Fix all kinds of bugs in file chunk manager test

### DIFF
--- a/src/server/chunk_server/file_chunk_manager.cc
+++ b/src/server/chunk_server/file_chunk_manager.cc
@@ -248,7 +248,7 @@ FileChunkManager::GetFileChunk(const std::string& chunk_handle,
 
   if (!result.ok()) {
     // Failed
-    return result;
+    return result.status();
   }
 
   auto& file_chunk = result.ValueOrDie();
@@ -258,7 +258,8 @@ FileChunkManager::GetFileChunk(const std::string& chunk_handle,
     // wrong version
     return google::protobuf::util::Status(
         google::protobuf::util::error::NOT_FOUND,
-        "Specified version doesn't match current version. Specified=" +
+        "Specified version for " + chunk_handle +
+            " doesn't match current version. Specified=" +
             std::to_string(version) +
             " Current=" + std::to_string(file_chunk->version()));
   }

--- a/src/server/chunk_server/file_chunk_manager.cc
+++ b/src/server/chunk_server/file_chunk_manager.cc
@@ -34,7 +34,7 @@ void FileChunkManager::Initialize(const std::string& chunk_database_name,
   leveldb::Status status =
       leveldb::DB::Open(options, chunk_database_name, &database);
 
-  LOG_ASSERT(status.ok());
+  LOG_ASSERT(status.ok()) << status.ToString();
 
   // Database is closed once pointer is deleted.
   this->chunk_database_ = std::unique_ptr<leveldb::DB>(database);

--- a/src/third_party/build_rules/leveldb.BUILD
+++ b/src/third_party/build_rules/leveldb.BUILD
@@ -23,6 +23,9 @@ cc_library(
     srcs = glob(
         ["**/*.cc"],
         exclude = [
+            "benchmarks/**",
+            "db/db_bench.cc",
+            "db/leveldbutil.cc",
             "doc/**",
             "**/*_test.cc",
             "util/env_windows.cc",
@@ -32,6 +35,7 @@ cc_library(
         ["**/*.h"],
         exclude = [
           "doc/**",
+          "benchmarks/**",
           "util/windows_logger.h",
           "util/env_windows*.h",
         ],


### PR DESCRIPTION
This reduces the test runtime from 50s-100s to 0.3s

The bugs fixed are

1. add status error strings for assertion failure, for ease of debugging
2. fix infinite recursion -> pushed directory to master already
3. fix incorrect use of database initialization
4. remove persistent test artifact directory
5. fix version increment errors
6. fix Bazel linker errors by removing benchmark binary from running in LevelDB