### PR TITLE
[feat]: Make chunkservers report to master on startup

### DIFF
--- a/src/server/chunk_server/BUILD.bazel
+++ b/src/server/chunk_server/BUILD.bazel
@@ -76,6 +76,7 @@ cc_library(
     hdrs = ["chunk_server_impl.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":file_chunk_manager",
         "//src/common:config_manager",
         "//src/common:system_logger",
         "//src/common:utils",

--- a/src/server/chunk_server/chunk_server_impl.cc
+++ b/src/server/chunk_server/chunk_server_impl.cc
@@ -3,6 +3,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/time/clock.h"
 #include "src/common/system_logger.h"
+#include "src/server/chunk_server/file_chunk_manager.h"
 
 using gfs::common::ConfigManager;
 using gfs::common::thread_safe_flat_hash_map;
@@ -10,6 +11,7 @@ using gfs::service::ChunkServerServiceChunkServerClient;
 using gfs::service::MasterChunkServerManagerServiceClient;
 using google::protobuf::util::Status;
 using google::protobuf::util::StatusOr;
+using protos::grpc::ReportChunkServerRequest;
 
 namespace gfs {
 namespace server {
@@ -100,13 +102,18 @@ ChunkServerImpl::GetMasterProtocolClient(const std::string& server_address) {
   if (master_server_clients_.contains(server_address)) {
     return master_server_clients_[server_address];
   } else {
-    LOG(INFO) << "Estabalishing new connection to master:" << server_address;
-    master_server_clients_[server_address] =
-        std::make_shared<MasterChunkServerManagerServiceClient>(
-            grpc::CreateChannel(server_address,
-                                grpc::InsecureChannelCredentials()));
+    RegisterMasterProtocolClient(server_address);
     return master_server_clients_[server_address];
   }
+}
+
+void ChunkServerImpl::RegisterMasterProtocolClient(
+    const std::string& server_address) {
+  LOG(INFO) << "Establishing new connection to master:" << server_address;
+  master_server_clients_[server_address] =
+      std::make_shared<MasterChunkServerManagerServiceClient>(
+          grpc::CreateChannel(server_address,
+                              grpc::InsecureChannelCredentials()));
 }
 
 std::shared_ptr<ChunkServerServiceChunkServerClient>
@@ -123,6 +130,60 @@ ChunkServerImpl::GetChunkServerProtocolClient(
                                 grpc::InsecureChannelCredentials()));
     return chunk_server_clients_[server_address];
   }
+}
+
+bool ChunkServerImpl::ReportToMaster() {
+  // Prepare the report chunk server request
+  ReportChunkServerRequest request;
+
+  // Add the chunk server information to the request
+  auto chunk_server = request.mutable_chunk_server();
+  auto chunk_server_location = chunk_server->mutable_location();
+
+  chunk_server_location->set_server_hostname(
+      config_manager_->GetServerHostname(chunk_server_name_));
+  chunk_server_location->set_server_port(
+      config_manager_->GetServerPort(chunk_server_name_));
+
+  // TODO(bmokutub): Use std::filesystem to get the available disk space.
+  // Setting to 20GB for now, fix this.
+  chunk_server->set_available_disk_mb(/*available_disk_mb=*/20 * 1024);
+
+  // We also need to tell the master all the chunks we have, if any.
+  auto all_chunks_metadata =
+      FileChunkManager::GetInstance()->GetAllFileChunkMetadata();
+
+  LOG(INFO) << "Found " + std::to_string(all_chunks_metadata.size()) +
+                   " stored chunks to report to master.";
+
+  for (auto& chunk_metadata : all_chunks_metadata) {
+    // TODO(bmokutub): Also include chunk version in request so master can check
+    // if it is stale. Not needed for now.
+    chunk_server->add_stored_chunk_handles(chunk_metadata.chunk_handle());
+  }
+
+  // send the request to the master server(s), if more than one
+  uint32_t successful_report = 0;
+  for (auto& master_chunk_server_mgr_client : master_server_clients_) {
+    LOG(INFO) << "Reporting to master server: " +
+                     master_chunk_server_mgr_client.first;
+
+    auto reply = master_chunk_server_mgr_client.second->SendRequest(request);
+    if (reply.ok()) {
+      // TODO(bmokutub): Check the reply for stale chunks, if any, for deletion.
+      // Not needed for now.
+      ++successful_report;
+    } else {
+      // failed
+      LOG(ERROR) << "Report chunk server request to master server: " +
+                        master_chunk_server_mgr_client.first +
+                        " failed. Status: " + reply.status().ToString();
+    }
+  }
+
+  // For now return true if atleast one of the report request succeeded. Meaning
+  // atleast one master server knows about this chunk server.
+  return successful_report > 0;
 }
 
 }  // namespace server

--- a/src/server/chunk_server/chunk_server_impl.h
+++ b/src/server/chunk_server/chunk_server_impl.h
@@ -44,9 +44,22 @@ class ChunkServerImpl {
   std::shared_ptr<gfs::service::MasterChunkServerManagerServiceClient>
   GetMasterProtocolClient(const std::string& server_address);
 
+  // Register (create) a protocol client for talking to the master at |server_address|.
+  // Overwrite any existing connection.
+  void RegisterMasterProtocolClient(const std::string& server_address);
+
   // Similar to GetMasterProtocolClient, but for talking to chunk servers.
   std::shared_ptr<gfs::service::ChunkServerServiceChunkServerClient>
   GetChunkServerProtocolClient(const std::string& server_address);
+
+  // Report this chunkserver to master server. This is useful during chunk
+  // server startup to inform the master, that it is now available, report the
+  // stored chunks and available disk. This enables the master to start issuing
+  // chunk allocations to this server. This functionality enables chunkservers
+  // to be dynamically added to the cluster, they just need to report themselves
+  // and the master will become aware of them and start issuing chunk
+  // allocations to them. Returns true if successful and false otherwise.
+  bool ReportToMaster();
 
  private:
   ChunkServerImpl() = default;

--- a/src/server/chunk_server/run_chunk_server_main.cc
+++ b/src/server/chunk_server/run_chunk_server_main.cc
@@ -14,8 +14,8 @@
 
 using gfs::common::ConfigManager;
 using gfs::server::ChunkServerImpl;
-using gfs::service::ChunkServerControlServiceImpl;
 using gfs::server::FileChunkManager;
+using gfs::service::ChunkServerControlServiceImpl;
 using gfs::service::ChunkServerFileServiceImpl;
 using gfs::service::ChunkServerLeaseServiceImpl;
 using google::protobuf::util::StatusOr;
@@ -77,6 +77,29 @@ int main(int argc, char** argv) {
   }
   ChunkServerImpl* chunk_server_impl = chunk_server_impl_or.ValueOrDie();
   LOG(INFO) << "Chunk server initialized...";
+
+  // Initialize gRPC protocol clients for talking to the master server(s) that
+  // should be available upon GFS cluster's startup time, based on initial
+  // config file.
+  for (std::string& master_server_name : config->GetAllMasterServers()) {
+    const std::string master_server_address =
+        config->GetServerAddress(master_server_name, resolve_hostname);
+
+    LOG(INFO) << "Initializing gRPC protocol client for talking to "
+              << master_server_name << " at " << master_server_address;
+
+    chunk_server_impl->RegisterMasterProtocolClient(master_server_address);
+  }
+
+  // This chunkserver should report itself to the master server(s). This will
+  // enable the master be aware of this chunkserver, and to start selecting it
+  // for chunk allocation. This also allows chunk servers to be dynamically
+  // added since they just need to report themselves to master.
+  if (!chunk_server_impl->ReportToMaster()) {
+    LOG(ERROR) << "Failed to report to any master server. Probably no master "
+                  "server is running. Shutting down...";
+    return 1;
+  }
 
   // Register synchronous services for handling clients' metadata requests
   // Note that gRPC only support providing services through via a single port.

--- a/src/server/master_server/BUILD.bazel
+++ b/src/server/master_server/BUILD.bazel
@@ -80,6 +80,7 @@ cc_library(
     name = "master_chunk_server_manager_service_impl",
     srcs = ["master_chunk_server_manager_service_impl.cc"],
     hdrs = ["master_chunk_server_manager_service_impl.h"],
+    visibility = ["//visibility:public"],
     deps = [
         ":chunk_server_manager",
         "//src/protos/grpc:cc_master_chunk_server_manager_service_grpc",

--- a/tests/common/BUILD.bazel
+++ b/tests/common/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
+exports_files(["test_config.yml"])
+
 cc_test(
     name = "utils_test",
     srcs = ["utils_test.cc"],

--- a/tests/server/master_server/BUILD.bazel
+++ b/tests/server/master_server/BUILD.bazel
@@ -30,3 +30,18 @@ cc_test(
         "@com_google_test//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "master_chunk_server_manager_service_test",
+    srcs = ["master_chunk_server_manager_service_test.cc"],
+    data = ["//tests/common:test_config.yml"],
+    deps = [
+        "//src/server/master_server:master_chunk_server_manager_service_impl",
+        "//src/server/chunk_server:file_chunk_manager",
+        "//src/common:config_manager",
+        "//src/server/chunk_server:chunk_server_impl",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf_lite",
+        "@com_google_test//:gtest_main",
+    ],
+)

--- a/tests/server/master_server/master_chunk_server_manager_service_test.cc
+++ b/tests/server/master_server/master_chunk_server_manager_service_test.cc
@@ -1,0 +1,136 @@
+#include <chrono>
+#include <thread>
+
+#include "google/protobuf/stubs/statusor.h"
+#include "grpcpp/grpcpp.h"
+#include "gtest/gtest.h"
+#include "src/common/config_manager.h"
+#include "src/server/chunk_server/chunk_server_impl.h"
+#include "src/server/chunk_server/file_chunk_manager.h"
+#include "src/server/master_server/chunk_server_manager.h"
+#include "src/server/master_server/master_chunk_server_manager_service_impl.h"
+
+using gfs::common::ConfigManager;
+using gfs::server::ChunkServerImpl;
+using gfs::server::ChunkServerManager;
+using gfs::server::FileChunkManager;
+using gfs::service::MasterChunkServerManagerServiceImpl;
+using google::protobuf::util::StatusOr;
+using grpc::Server;
+using grpc::ServerBuilder;
+using protos::grpc::ReportChunkServerReply;
+using protos::grpc::ReportChunkServerRequest;
+
+const std::string kTestConfigPath = "tests/common/test_config.yml";
+const std::string kTestMasterServerName = "test_master";
+const std::string kTestMasterServerAddress = "0.0.0.0:10002";
+const std::string kTestChunkServerName = "test_chunk_server_01";
+
+namespace {
+void StartTestMasterChunkServerManagerService() {
+  ServerBuilder builder;
+  auto credentials = grpc::InsecureServerCredentials();
+  builder.AddListeningPort(kTestMasterServerAddress, credentials);
+
+  // Register a synchronous service for coordinating with chunkservers
+  MasterChunkServerManagerServiceImpl chunk_server_mgr_service;
+  builder.RegisterService(&chunk_server_mgr_service);
+
+  // Start the server, and let it run until thread is cancelled
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+
+  server->Wait();
+}
+}  // namespace
+
+class MasterChunkServerManagerServiceTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    // Need file chunk manager to be initialized because of the report chunk
+    // server needs to check for stored chunks.
+    // The DB can only be initialized and open once by each thread, so we put
+    // it in SetUpTestSuite for one-time setup
+    FileChunkManager* file_chunk_mgr = FileChunkManager::GetInstance();
+    file_chunk_mgr->Initialize(
+        // Do NOT use /tmp as the test artifacts will persist this way
+        // Instead, use relative directory for Bazel test so it will be cleaned
+        // up after the test finishes
+        /*chunk_database_name=*/"master_chunk_server_manager_service_test_db",
+        /*max_chunk_size_bytes=*/100);
+  }
+
+  void SetUp() override {
+    // Create the config manager for the test to read test config.
+    config_mgr_ = std::shared_ptr<ConfigManager>(
+        ConfigManager::GetConfig(kTestConfigPath).ValueOrDie());
+  }
+
+  // Executed after each test method in the suite.
+  void TearDown() override {
+    // Unregister all the ChunkServers registered by the test.
+    ChunkServerManager::GetInstance().UnRegisterAllChunkServers();
+  }
+
+  std::shared_ptr<ConfigManager> config_mgr_;
+};
+
+// This tests a chunkserver that reports itself to master and master registers
+// it and starts using it for chunk allocation.
+TEST_F(MasterChunkServerManagerServiceTest, ReportChunkServerTest) {
+  // Create the chunkserver
+  StatusOr<ChunkServerImpl*> chunk_server_or =
+      ChunkServerImpl::ConstructChunkServerImpl(kTestConfigPath,
+                                                kTestChunkServerName);
+  ChunkServerImpl* chunk_server = chunk_server_or.ValueOrDie();
+
+  // Get the master server address
+  const std::string master_server_address = config_mgr_->GetServerAddress(
+      kTestMasterServerName, /*resolve_hostname=*/true);
+  // Check that we got the right master address from config manager
+  EXPECT_EQ(kTestMasterServerAddress, master_server_address);
+
+  // Chunk server creates connection to the master server.
+  chunk_server->RegisterMasterProtocolClient(master_server_address);
+
+  // Check that the chunk server was able to report itself to the master server.
+  EXPECT_TRUE(chunk_server->ReportToMaster());
+
+  // The chunk server manager runs on the master server, but here since master
+  // is just running as a seperate thread we can check if the report chunkserver
+  // was truly successful and master can now select chunkserver for chunk
+  // allocation.
+  auto allocated_locations =
+      ChunkServerManager::GetInstance().AllocateChunkServer(
+          /*chunk_handle=*/"TestHandle", /*server_count=*/1);
+
+  EXPECT_EQ(1, allocated_locations.size());
+
+  // Now verify that the allocated chunk server is the chunk server we reported,
+  // since its the only one reported.
+  protos::ChunkServerLocation chunk_server_location;
+  chunk_server_location.set_server_hostname(
+      config_mgr_->GetServerHostname(kTestChunkServerName));
+  chunk_server_location.set_server_port(
+      config_mgr_->GetServerPort(kTestChunkServerName));
+
+  EXPECT_EQ(chunk_server_location, *allocated_locations.begin());
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Start the MasterChunkServerManagerService in the background, and wait for
+  // some time for the server to be successfully started in the background.
+  std::thread master_server_thread =
+      std::thread(StartTestMasterChunkServerManagerService);
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+
+  // Run tests
+  int exit_code = RUN_ALL_TESTS();
+
+  // Clean up background server
+  pthread_cancel(master_server_thread.native_handle());
+  master_server_thread.join();
+
+  return exit_code;
+}


### PR DESCRIPTION
This enables chunk servers to report to master when they are starting up. A starting chunk server inform the master, that it is now available, report the stored chunks (if any) and available disk. This enables the master to start issuing chunk allocations to this server. This functionality enables chunk servers to be dynamically added to the cluster, they just need to report themselves and the master will become aware of them and start issuing chunk allocations to them.

Changes:
1. Chunkserver report to master servers on startup.
2. Test that runs both master and chunkserver and checks that when chunkserver reports itself to master, the chunkserver is now available to be used for chunk allocation.