### PR TITLE
[feat] A simple chunk data cache manager

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -108,6 +108,12 @@ class parallel_hash_map : public phmap::parallel_flat_hash_map<Key, Value> {
     (*this)[key] = value;
   }
 
+  // Erase the value for a key
+  void Erase(const Key& key) {
+    absl::Mutex* lock(FetchLock(key));
+    absl::WriterMutexLock lock_guard(lock);
+    this->erase(key);
+  }
  private:
   std::vector<std::shared_ptr<absl::Mutex>> locks_;
   absl::Mutex* FetchLock(const Key& key) {

--- a/src/server/chunk_server/BUILD.bazel
+++ b/src/server/chunk_server/BUILD.bazel
@@ -7,8 +7,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/common:utils",
-        "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/synchronization",
         "@com_google_protobuf//:protobuf_lite"
     ],
 )

--- a/src/server/chunk_server/BUILD.bazel
+++ b/src/server/chunk_server/BUILD.bazel
@@ -1,6 +1,19 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 cc_library(
+    name = "chunk_data_cache_manager",
+    srcs = ["chunk_data_cache_manager.cc"],
+    hdrs = ["chunk_data_cache_manager.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/common:utils",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_protobuf//:protobuf_lite"
+    ],
+)
+
+cc_library(
     name = "chunk_server_lease_service_impl",
     srcs = ["chunk_server_lease_service_impl.cc"],
     hdrs = ["chunk_server_lease_service_impl.h"],

--- a/src/server/chunk_server/chunk_data_cache_manager.cc
+++ b/src/server/chunk_server/chunk_data_cache_manager.cc
@@ -1,0 +1,63 @@
+#include "src/server/chunk_server/chunk_data_cache_manager.h"
+
+namespace gfs {
+namespace server {
+
+google::protobuf::util::StatusOr<std::string> ChunkDataCacheManager::GetValue(
+    const std::string& key) {
+  auto try_get_value(data_cache_.TryGetValue(key));
+  if (!try_get_value.second) {
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::NOT_FOUND,
+        "Value not found for key: " + key);
+  }
+  return try_get_value.first;
+}
+
+google::protobuf::util::Status ChunkDataCacheManager::SetValue(
+    const std::string& key, const std::string& value) {
+  size_t data_size(value.size());
+
+  // The very corner case that a huge value singly exceeds cache capcity do not
+  // expect to have in this project
+  if (data_size > cache_capacity_limit_) {
+    return google::protobuf::util::Status(
+        google::protobuf::util::error::OUT_OF_RANGE,
+        "Value exceeds cache capacity");
+  }
+
+  // The eviction case as the we reach capacity. Note that for simplicity we do
+  // not consider all the crazy concurrent scheme that can happen here
+  while (cache_capacity_.load() + data_size > cache_capacity_limit_) {
+    // Lock the key_history_ set and evict the data that corresponds to the 
+    // first key there
+    absl::WriterMutexLock lock_guard(&key_history_lock_);
+    // In this case the key_history_ cannot be empty so begin exists
+    auto key_to_evict(*key_history_.begin());
+    key_history_.erase(key_history_.begin());
+    // We are under a single lock, so directly accessing / deleting is safe
+    size_t value_to_evict_len(data_cache_[key_to_evict].size());
+    data_cache_.erase(key_to_evict);
+    cache_capacity_ -= value_to_evict_len;
+  }
+  
+  // Set the value and update the cache capacity
+  data_cache_.SetValue(key, value);
+  return google::protobuf::util::Status::OK;
+}
+
+// Note that this function is only used by test, and is not thread-safe
+// for simplicity
+void ChunkDataCacheManager::SetCacheCapacityLimit(
+    const unsigned long cache_capacity_limit) {
+  cache_capacity_limit_ = cache_capacity_limit;
+}
+
+ChunkDataCacheManager* GetInstance() {
+  static ChunkDataCacheManager* chunk_data_cache_manager 
+      = new ChunkDataCacheManager();
+  return chunk_data_cache_manager;
+}
+
+} // namespace server
+} // namespace gfs

--- a/src/server/chunk_server/chunk_data_cache_manager.cc
+++ b/src/server/chunk_server/chunk_data_cache_manager.cc
@@ -14,46 +14,16 @@ google::protobuf::util::StatusOr<std::string> ChunkDataCacheManager::GetValue(
   return try_get_value.first;
 }
 
-google::protobuf::util::Status ChunkDataCacheManager::SetValue(
-    const std::string& key, const std::string& value) {
-  size_t data_size(value.size());
-
-  // The very corner case that a huge value singly exceeds cache capcity do not
-  // expect to have in this project
-  if (data_size > cache_capacity_limit_) {
-    return google::protobuf::util::Status(
-        google::protobuf::util::error::OUT_OF_RANGE,
-        "Value exceeds cache capacity");
-  }
-
-  // The eviction case as the we reach capacity. Note that for simplicity we do
-  // not consider all the crazy concurrent scheme that can happen here
-  while (cache_capacity_.load() + data_size > cache_capacity_limit_) {
-    // Lock the key_history_ set and evict the data that corresponds to the 
-    // first key there
-    absl::WriterMutexLock lock_guard(&key_history_lock_);
-    // In this case the key_history_ cannot be empty so begin exists
-    auto key_to_evict(*key_history_.begin());
-    key_history_.erase(key_history_.begin());
-    // We are under a single lock, so directly accessing / deleting is safe
-    size_t value_to_evict_len(data_cache_[key_to_evict].size());
-    data_cache_.erase(key_to_evict);
-    cache_capacity_ -= value_to_evict_len;
-  }
-  
-  // Set the value and update the cache capacity
+void ChunkDataCacheManager::SetValue(const std::string& key, 
+    const std::string& value) {
   data_cache_.SetValue(key, value);
-  return google::protobuf::util::Status::OK;
 }
 
-// Note that this function is only used by test, and is not thread-safe
-// for simplicity
-void ChunkDataCacheManager::SetCacheCapacityLimit(
-    const unsigned long cache_capacity_limit) {
-  cache_capacity_limit_ = cache_capacity_limit;
+void ChunkDataCacheManager::RemoveValue(const std::string& key) {
+  data_cache_.Erase(key);
 }
 
-ChunkDataCacheManager* GetInstance() {
+ChunkDataCacheManager* ChunkDataCacheManager::GetInstance() {
   static ChunkDataCacheManager* chunk_data_cache_manager 
       = new ChunkDataCacheManager();
   return chunk_data_cache_manager;

--- a/src/server/chunk_server/chunk_data_cache_manager.h
+++ b/src/server/chunk_server/chunk_data_cache_manager.h
@@ -1,0 +1,66 @@
+#ifndef GFS_SERVER_CHUNK_SERVER_CHUNK_DATA_CACHE_MANAGER_H_
+#define GFS_SERVER_CHUNK_SERVER_CHUNK_DATA_CACHE_MANAGER_H_
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/synchronization/mutex.h"
+#include "google/protobuf/stubs/status.h"
+#include "google/protobuf/stubs/statusor.h"
+#include "src/common/utils.h"
+
+// Singleton class responsible for managing the data cache and retrival for
+// file chunk data that sent from client to chunk servers. It employs thread-
+// safe hashmap to store the key-value pairs, where the key is typically the
+// checksum of the data and the value is a string. In order to keep the cache
+// under a size limit, we employ a LRU eviction policy when the cache is at
+// capacity.
+
+namespace gfs {
+namespace server {
+
+class ChunkDataCacheManager {
+ public:
+  // Static method to access the singleton object
+  static ChunkDataCacheManager* GetInstance();   
+
+  // Get value for a key, return error if key not found
+  google::protobuf::util::StatusOr<std::string> GetValue(
+      const std::string& key);
+
+  // Set value for a key, return error if this operation is unsuccessful. This 
+  // can happen if this value is bigger than the capacity of the whole cache 
+  // capacity. Otherwise, we will always set the value for this key. We evict 
+  // as much as possible data to make this insertion as this happens as the 
+  // latest operation
+  google::protobuf::util::Status SetValue(const std::string& key, 
+  				          const std::string& value);
+ 
+  // Set cache capacity in bytes. This is only useful for testing as the
+  // default value is very large
+  void SetCacheCapacityLimit(const unsigned long cache_capacity_limit);
+
+ private:
+  // A capacity cap for this cache unit. Default value 4G
+  // TODO(Xi): this value needs to be configurable. 
+  unsigned long cache_capacity_limit_ = 4294967296;
+
+  // Cache capacity in bytes
+  std::atomic<unsigned long> cache_capacity_{0};
+
+  // A thread-safe hashmap to store the key-value mapping
+  common::parallel_hash_map<std::string, std::string> data_cache_;
+
+  // A hash-set to store the history of keys that got inserted. This 
+  // will be useful when eviction is needed. For simplicity, we will just
+  // remove the first key in this set, and the reason of not using a 
+  // thread-safe data structure for this one is that iterator usage becomes
+  // tricky, we use a single lock to serialize operations
+  absl::flat_hash_set<std::string> key_history_;
+
+  // A lock to synchronize key_history
+  absl::Mutex key_history_lock_; 
+};
+
+} // namespace server
+} // namespace gfs
+
+#endif // GFS_SERVER_CHUNK_SERVER_CHUNK_DATA_CACHE_MANAGER_H_

--- a/src/server/chunk_server/chunk_data_cache_manager.h
+++ b/src/server/chunk_server/chunk_data_cache_manager.h
@@ -1,8 +1,6 @@
 #ifndef GFS_SERVER_CHUNK_SERVER_CHUNK_DATA_CACHE_MANAGER_H_
 #define GFS_SERVER_CHUNK_SERVER_CHUNK_DATA_CACHE_MANAGER_H_
 
-#include "absl/container/flat_hash_set.h"
-#include "absl/synchronization/mutex.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/stubs/statusor.h"
 #include "src/common/utils.h"
@@ -10,9 +8,20 @@
 // Singleton class responsible for managing the data cache and retrival for
 // file chunk data that sent from client to chunk servers. It employs thread-
 // safe hashmap to store the key-value pairs, where the key is typically the
-// checksum of the data and the value is a string. In order to keep the cache
-// under a size limit, we employ a LRU eviction policy when the cache is at
-// capacity.
+// checksum of the data and the value is a string. For simplicity, we let the 
+// caller of this module to remove items (this can happen typically after a 
+// write operation is successfully executed). 
+// 
+// Example: use ChunkDataCacheManager::GetInstance()->GetValue(key) to get the
+// value for a key. 
+//
+// Use ChunkDataCacheManager::GetInstance()->SetValue(key, value) to set the
+// value for a key.
+//
+// Use ChunkDataCacheManager::GetInstance()->RemoveValue(key) to remove the 
+// value for a key. 
+//
+// Remember to check error. 
 
 namespace gfs {
 namespace server {
@@ -26,38 +35,15 @@ class ChunkDataCacheManager {
   google::protobuf::util::StatusOr<std::string> GetValue(
       const std::string& key);
 
-  // Set value for a key, return error if this operation is unsuccessful. This 
-  // can happen if this value is bigger than the capacity of the whole cache 
-  // capacity. Otherwise, we will always set the value for this key. We evict 
-  // as much as possible data to make this insertion as this happens as the 
-  // latest operation
-  google::protobuf::util::Status SetValue(const std::string& key, 
-  				          const std::string& value);
- 
-  // Set cache capacity in bytes. This is only useful for testing as the
-  // default value is very large
-  void SetCacheCapacityLimit(const unsigned long cache_capacity_limit);
+  // Set value for a key
+  void SetValue(const std::string& key, const std::string& value);
+
+  // Remove value for a key, regardless of the existence of this key
+  void RemoveValue(const std::string& key);
 
  private:
-  // A capacity cap for this cache unit. Default value 4G
-  // TODO(Xi): this value needs to be configurable. 
-  unsigned long cache_capacity_limit_ = 4294967296;
-
-  // Cache capacity in bytes
-  std::atomic<unsigned long> cache_capacity_{0};
-
   // A thread-safe hashmap to store the key-value mapping
   common::parallel_hash_map<std::string, std::string> data_cache_;
-
-  // A hash-set to store the history of keys that got inserted. This 
-  // will be useful when eviction is needed. For simplicity, we will just
-  // remove the first key in this set, and the reason of not using a 
-  // thread-safe data structure for this one is that iterator usage becomes
-  // tricky, we use a single lock to serialize operations
-  absl::flat_hash_set<std::string> key_history_;
-
-  // A lock to synchronize key_history
-  absl::Mutex key_history_lock_; 
 };
 
 } // namespace server

--- a/tests/server/chunk_server/BUILD.bazel
+++ b/tests/server/chunk_server/BUILD.bazel
@@ -1,6 +1,17 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
 cc_test(
+    name = "chunk_data_cache_manager_test",
+    srcs = ["chunk_data_cache_manager_test.cc"],
+    deps = [
+        "//src/server/chunk_server:chunk_data_cache_manager",
+        "//tests:utils",
+        "@com_google_protobuf//:protobuf_lite",
+        "@com_google_test//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "chunk_server_impl_test",
     srcs = ["chunk_server_impl_test.cc"],
     data = ["test_config.yml"],

--- a/tests/server/chunk_server/chunk_data_cache_manager_test.cc
+++ b/tests/server/chunk_server/chunk_data_cache_manager_test.cc
@@ -1,0 +1,90 @@
+#include "src/server/chunk_server/chunk_data_cache_manager.h"
+
+#include <thread>
+#include "gtest/gtest.h"
+#include "tests/utils.h"
+
+using namespace gfs::server;
+using namespace tests;
+
+class ChunkDataCacheManagerTest : public ::testing::Test {
+ protected:  
+  void SetUp() override {
+    chunk_data_cache_mgr_ = ChunkDataCacheManager::GetInstance();
+  }
+  ChunkDataCacheManager* chunk_data_cache_mgr_;
+};
+
+TEST_F(ChunkDataCacheManagerTest, BasicTestCase) {
+  std::string key_base_name("foo");
+  std::string data_base("foo_data");
+
+  // Set value for 100 items
+  for (int i = 0; i < 100; i++) {
+    chunk_data_cache_mgr_->SetValue(key_base_name + std::to_string(i),
+                                    data_base + std::to_string(i));
+  }
+
+  // Check value for all
+  for (int i = 0; i < 100; i++) {
+    auto get_or(chunk_data_cache_mgr_->GetValue(
+                    key_base_name + std::to_string(i)));
+    EXPECT_TRUE(get_or.ok());
+    EXPECT_EQ(get_or.ValueOrDie(), data_base + std::to_string(i));
+  }
+}
+
+TEST_F(ChunkDataCacheManagerTest, ConcurrentInsertionAndDeletionTest) {
+  auto num_of_threads(50);
+  std::string key_base_name("bar");
+  std::string data_base("bar_data");
+  std::vector<std::thread> threads;
+
+  // Concurrent insertion
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string key_base_thread(key_base_name + std::to_string(i));
+      std::string data_base_thread(data_base + std::to_string(i));
+      for (int j = 0; j < 100; j++) {
+        chunk_data_cache_mgr_->SetValue(key_base_thread + std::to_string(j),
+                                        data_base_thread + std::to_string(j));
+      }
+    }));
+  }
+
+  JoinAndClearThreads(threads);
+
+  // Concurrent access and checking
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string key_base_thread(key_base_name + std::to_string(i));
+      std::string data_base_thread(data_base + std::to_string(i));
+      for (int j = 0; j < 100; j++) {
+        auto get_or(chunk_data_cache_mgr_->GetValue(key_base_thread 
+                                                        + std::to_string(j)));
+        EXPECT_TRUE(get_or.ok());
+        EXPECT_EQ(get_or.ValueOrDie(), data_base_thread + std::to_string(j));
+      }
+    }));
+  }
+
+  JoinAndClearThreads(threads);
+
+  // Concurrent deletion and checking
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string key_base_thread(key_base_name + std::to_string(i));
+      std::string data_base_thread(data_base + std::to_string(i));
+      for (int j = 0; j < 100; j++) {
+        std::string key(key_base_thread + std::to_string(j));
+        chunk_data_cache_mgr_->RemoveValue(key);
+        auto get_or(chunk_data_cache_mgr_->GetValue(key));
+        EXPECT_EQ(get_or.status().error_code(),
+                  google::protobuf::util::error::NOT_FOUND);
+      }
+    }));
+  }
+
+  JoinAndClearThreads(threads);
+}
+


### PR DESCRIPTION
Quickly sketched a simple chunk data cache manager to store the chunk data sent from client to chunk server. 

No eviction is currently implemented, and provided an interface to remove key (this can happen after successfully executing a write). 

NOTE: concurrent hash map + eviction is tricky, even we just wanted a simplest form. Lots of questions need to be addressed, for instance, to keep track of the total data size instead of just the number of items, to keep a list of keys to be deleted. And things easily get complicated when concurrency is taking place.

This simple form should suffice for our test cases. If time allows we could add eviction. 