### PR TITLE
Benchmark Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Make sure you have [Docker](https://docs.docker.com/engine/install/) and [Docker
 To start all servers and expose respective server ports outside of Docker for connection, run:
 
 ```
+docker-compose build
 docker-compose up
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,3 +98,13 @@ http_archive(
     strip_prefix = "yaml-cpp-yaml-cpp-0.6.3",
     urls = ["https://github.com/jbeder/yaml-cpp/archive/yaml-cpp-0.6.3.tar.gz"],
 )
+
+# Google Benchmark library
+http_archive(
+    name = "com_google_benchmark",
+    sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",
+    strip_prefix = "benchmark-1.5.0",
+    urls = [
+        "https://github.com/google/benchmark/archive/v1.5.0.tar.gz",
+    ],
+)

--- a/src/benchmarks/BUILD.bazel
+++ b/src/benchmarks/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_binary(
+    name = "init_open_bench",
+    srcs = ["init_open_bench.cc"],
+    data = ["//data:config.yml"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/client:gfs_client",
+        "@com_google_benchmark//:benchmark",
+        "@com_google_glog//:glog",
+    ],
+)

--- a/src/benchmarks/init_open_bench.cc
+++ b/src/benchmarks/init_open_bench.cc
@@ -4,13 +4,13 @@
 
 const char kConfigFileName[] = "data/config.yml";
 const char kMasterName[] = "master_server_01";
-const bool resolve_hostname = true;
+const bool kResolveHostname = true;
 
-static void BM_INIT_CILENT(benchmark::State& state) {
+static void BM_INIT_CLIENT(benchmark::State& state) {
   // Benchmark the init_client function
   for (auto _ : state) {
     auto init_status(gfs::client::init_client(kConfigFileName, kMasterName,
-                                              resolve_hostname));
+                                              kResolveHostname));
     // delete the cached client impl, so we can run it again
     state.PauseTiming();
     gfs::client::reset_client();
@@ -20,7 +20,7 @@ static void BM_INIT_CILENT(benchmark::State& state) {
 
 static void BM_OPEN_WITH_READ_MODE(benchmark::State& state) {
   auto init_status(
-      gfs::client::init_client(kConfigFileName, kMasterName, resolve_hostname));
+      gfs::client::init_client(kConfigFileName, kMasterName, kResolveHostname));
   // Benchmark the init_client function
   state.counters["ok"] = 0;
   state.counters["failed"] = 0;
@@ -38,7 +38,7 @@ static void BM_OPEN_WITH_READ_MODE(benchmark::State& state) {
 
 static void BM_OPEN_WITH_WRITE_MODE(benchmark::State& state) {
   auto init_status(
-      gfs::client::init_client(kConfigFileName, kMasterName, resolve_hostname));
+      gfs::client::init_client(kConfigFileName, kMasterName, kResolveHostname));
   // Benchmark the init_client function
   state.counters["ok"] = 0;
   state.counters["failed"] = 0;
@@ -57,7 +57,7 @@ static void BM_OPEN_WITH_WRITE_MODE(benchmark::State& state) {
 
 static void BM_OPEN_WITH_CREATE_MODE(benchmark::State& state) {
   auto init_status(
-      gfs::client::init_client(kConfigFileName, kMasterName, resolve_hostname));
+      gfs::client::init_client(kConfigFileName, kMasterName, kResolveHostname));
   // Benchmark the init_client function
   state.counters["ok"] = 0;
   state.counters["failed"] = 0;
@@ -75,7 +75,7 @@ static void BM_OPEN_WITH_CREATE_MODE(benchmark::State& state) {
 }
 
 // Register the function as a benchmark
-BENCHMARK(BM_INIT_CILENT);
+BENCHMARK(BM_INIT_CLIENT);
 BENCHMARK(BM_OPEN_WITH_READ_MODE);
 BENCHMARK(BM_OPEN_WITH_WRITE_MODE);
 BENCHMARK(BM_OPEN_WITH_CREATE_MODE);

--- a/src/benchmarks/init_open_bench.cc
+++ b/src/benchmarks/init_open_bench.cc
@@ -1,0 +1,91 @@
+#include "benchmark/benchmark.h"
+#include "glog/logging.h"
+#include "src/client/gfs_client.h"
+
+const char kConfigFileName[] = "data/config.yml";
+const char kMasterName[] = "master_server_01";
+const bool resolve_hostname = true;
+
+static void BM_INIT_CILENT(benchmark::State& state) {
+  // Benchmark the init_client function
+  for (auto _ : state) {
+    auto init_status(gfs::client::init_client(kConfigFileName, kMasterName,
+                                              resolve_hostname));
+    // delete the cached client impl, so we can run it again
+    state.PauseTiming();
+    gfs::client::reset_client();
+    state.ResumeTiming();
+  }
+}
+
+static void BM_OPEN_WITH_READ_MODE(benchmark::State& state) {
+  auto init_status(
+      gfs::client::init_client(kConfigFileName, kMasterName, resolve_hostname));
+  // Benchmark the init_client function
+  state.counters["ok"] = 0;
+  state.counters["failed"] = 0;
+  for (auto _ : state) {
+    auto status_or = gfs::client::open("/open_with_read", gfs::OpenFlag::Read);
+    state.PauseTiming();
+    if (status_or.ok()) {
+      state.counters["ok"]++;
+    } else {
+      state.counters["failed"]++;
+    }
+    state.ResumeTiming();
+  }
+}
+
+static void BM_OPEN_WITH_WRITE_MODE(benchmark::State& state) {
+  auto init_status(
+      gfs::client::init_client(kConfigFileName, kMasterName, resolve_hostname));
+  // Benchmark the init_client function
+  state.counters["ok"] = 0;
+  state.counters["failed"] = 0;
+  for (auto _ : state) {
+    auto status_or =
+        gfs::client::open("/open_with_write", gfs::OpenFlag::Write);
+    state.PauseTiming();
+    if (status_or.ok()) {
+      state.counters["ok"]++;
+    } else {
+      state.counters["failed"]++;
+    }
+    state.ResumeTiming();
+  }
+}
+
+static void BM_OPEN_WITH_CREATE_MODE(benchmark::State& state) {
+  auto init_status(
+      gfs::client::init_client(kConfigFileName, kMasterName, resolve_hostname));
+  // Benchmark the init_client function
+  state.counters["ok"] = 0;
+  state.counters["failed"] = 0;
+  for (auto _ : state) {
+    auto status_or =
+        gfs::client::open("/open_with_create", gfs::OpenFlag::Create);
+    state.PauseTiming();
+    if (status_or.ok()) {
+      state.counters["ok"]++;
+    } else {
+      state.counters["failed"]++;
+    }
+    state.ResumeTiming();
+  }
+}
+
+// Register the function as a benchmark
+BENCHMARK(BM_INIT_CILENT);
+BENCHMARK(BM_OPEN_WITH_READ_MODE);
+BENCHMARK(BM_OPEN_WITH_WRITE_MODE);
+BENCHMARK(BM_OPEN_WITH_CREATE_MODE);
+
+// Instead of using BENCHMARK_MAIN, we manually write the main to allows
+// use initialize the google logging, to surpress the INFO log being logged
+// to stderr by default when glog is not explicitly initialized
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(/*program_name*/ argv[0]);
+  ::benchmark::Initialize(&argc, argv);
+  if (::benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
+  ::benchmark::RunSpecifiedBenchmarks();
+}

--- a/src/client/gfs_client.cc
+++ b/src/client/gfs_client.cc
@@ -68,10 +68,15 @@ google::protobuf::util::Status open(const char* filename, unsigned int flags) {
 
   // Creation mode, this is true when flags = OpenFlag::Create or
   // Open::Create | Open::Write
-  if (flags == OpenFlag::Create ||
-      flags == (OpenFlag::Create | OpenFlag::Write)) {
+  if (flags == OpenFlag::Create) {
     auto create_status(client_impl_->CreateFile(filename));
     if (!create_status.ok()) {
+      return create_status;
+    }
+  } else if (flags == (OpenFlag::Create | OpenFlag::Write)) {
+    auto create_status(client_impl_->CreateFile(filename));
+    if (!create_status.ok() &&
+        create_status.code() != google::protobuf::util::error::ALREADY_EXISTS) {
       return create_status;
     }
   }

--- a/src/client/gfs_client.h
+++ b/src/client/gfs_client.h
@@ -33,6 +33,9 @@ struct Data {
 google::protobuf::util::Status init_client(const std::string& config_filename,
     const std::string& master_name, const bool resolve_hostname = false);
 
+// Reset client as if it was never initialized
+void reset_client();
+
 // We support the following mode: Read Mode | Write Mode | Create Mode
 // when opening a file. The only possible combination is Write | Create. 
 // The flags is an unsigned integer (similar to the open system call) which


### PR DESCRIPTION
In this PR, we introduce Google Benchmark library (https://github.com/google/benchmark) and a start benchmark script for benchmarking client init and open operation speed.

In the meantime, fix some bugs in the gfs client 