### PR TITLE
simple fix to the race condition

### DIFF
--- a/tests/server/master_server/chunk_server_manager_test.cc
+++ b/tests/server/master_server/chunk_server_manager_test.cc
@@ -451,7 +451,7 @@ TEST_F(ChunkServerManagerTest, ConcurrentRegisterAndAllocateChunkServers) {
 
   // concurrently register 5 more chunservers and allocate 8 chunkservers
   // Using 8 here since allocation is usually faster than registration.
-  ushort server_allocation_thread_count = chunk_servers_count - 2;
+  ushort server_allocation_thread_count = preregistered_servers_count;
   std::vector<std::future<ChunkServerLocationThreadSafeFlatSet>>
       server_allocation_thread_futures;
 


### PR DESCRIPTION
given concurrent add servers may start after the allocations complete, this test is only always safe  and non-flaky if even no more chunk servers are added and we are allocating only using preregistered chunk servers, we still have each allocation assigned to a single server