### PR TITLE
[feat] - WriteRequest and ApplyMutation implementation for chunk server file service

### DIFF
--- a/src/common/protocol_client/chunk_server_service_server_client.cc
+++ b/src/common/protocol_client/chunk_server_service_server_client.cc
@@ -89,5 +89,11 @@ ChunkServerServiceMasterServerClient::SendRequest(
   return SendRequest(request, default_context);
 }
 
+StatusOr<ApplyMutationsReply> ChunkServerServiceChunkServerClient::SendRequest(
+    const ApplyMutationsRequest& request) {
+  ClientContext default_context;
+  return SendRequest(request, default_context);
+}
+
 }  // namespace service
 }  // namespace gfs

--- a/src/common/protocol_client/chunk_server_service_server_client.h
+++ b/src/common/protocol_client/chunk_server_service_server_client.h
@@ -81,8 +81,6 @@ class ChunkServerServiceMasterServerClient {
   std::unique_ptr<protos::grpc::ChunkServerFileService::Stub> file_stub_;
 };
 
-
-
 // Communication manager for fellow chunk servers to send gRPC amongst
 // themselves doing file related, and replication related operations.
 //
@@ -105,7 +103,8 @@ class ChunkServerServiceChunkServerClient {
   // Send an ApplyMutations gRPC |request| to the chunk server, and return chunk
   // server's corresponding reply if successful; otherwise a Status with error
   // message. This method is synchronous and will block until it hears from the
-  // chunk server. This gRPC is only sent by master to the chunk server.
+  // chunk server. This gRPC is only sent by primary chunk server to the other
+  // replica chunk servers during write request.
   google::protobuf::util::StatusOr<protos::grpc::ApplyMutationsReply>
   SendRequest(const protos::grpc::ApplyMutationsRequest& request);
   google::protobuf::util::StatusOr<protos::grpc::ApplyMutationsReply>

--- a/src/protos/grpc/chunk_server_file_service.proto
+++ b/src/protos/grpc/chunk_server_file_service.proto
@@ -178,7 +178,8 @@ message SendChunkDataReply {
     OK = 1;
     RATE_LIMITED = 2; // not used, but as an example of what we can have
     DATA_TOO_BIG = 3; // data is bigger than allowed GFS file chunk block size
-    FAILED = 4;
+    BAD_DATA = 4; // checksum for data sent doesn't match the calculated checksum
+    FAILED = 5;
   }
   SendChunkDataRequestStatus status = 2;
 }

--- a/src/protos/grpc/chunk_server_file_service.proto
+++ b/src/protos/grpc/chunk_server_file_service.proto
@@ -167,7 +167,7 @@ message SendChunkDataRequest {
   bytes data = 1;
   // The checksum for uniquely identifying this data across requests, so
   // future requests don't need to resend the data, unless the data expired.
-  string checksum = 2;
+  bytes checksum = 2;
 }
 
 message SendChunkDataReply {
@@ -194,7 +194,7 @@ message WriteFileChunkRequestHeader {
   uint32 length = 4;
   // The checksum for uniquely identifying the data previously sent to all 
   // replicas already via SendChunkData gRPC.
-  string data_checksum = 5;
+  bytes data_checksum = 5;
 }
 
 message ApplyMutationsRequest {
@@ -215,6 +215,8 @@ enum FileChunkMutationStatus {
   // This only applies if a client tries to send a WriteRequest to a secondary
   // replica; it'll not error when ApplyMutationRequests are sent by the primary
   FAILED_NOT_LEASE_HOLDER = 5;
+  // Failed because the write start offset is outside the allowed range
+  FAILED_OUT_OF_RANGE = 6;
 }
 
 

--- a/src/server/chunk_server/BUILD.bazel
+++ b/src/server/chunk_server/BUILD.bazel
@@ -33,6 +33,9 @@ cc_library(
     deps = [
         ":chunk_server_impl",
         ":file_chunk_manager",
+        ":chunk_data_cache_manager",
+        "//src/common/protocol_client:chunk_server_service_server_client",
+        "//src/common:utils",
         "//src/common:system_logger",
         "//src/protos/grpc:cc_chunk_server_file_service_grpc",
         "@com_github_grpc_grpc//:grpc++",

--- a/src/server/chunk_server/chunk_server_file_service_impl.h
+++ b/src/server/chunk_server/chunk_server_file_service_impl.h
@@ -53,6 +53,16 @@ class ChunkServerFileServiceImpl final
   gfs::server::ChunkServerImpl* chunk_server_impl_;
   gfs::server::FileChunkManager* file_manager_ =
       gfs::server::FileChunkManager::GetInstance();
+
+ private:
+  // Internal helper method to write file chunk to the local file chunk manager
+  // and set reply status to the appropriate FileChunkMutationStatus. This is
+  // used by both WriteFileChunk and ApplyMutations, to apply writes locally. It
+  // gets the write data from cache if exist, and uses the file manager to write
+  // data to the file chunk on disk.
+  grpc::Status WriteFileChunkInternal(
+      const protos::grpc::WriteFileChunkRequestHeader& request_header,
+      protos::grpc::WriteFileChunkReply* const reply);
 };
 
 // The asynchronous implementation for handling ChunkServerFileService requests

--- a/src/server/chunk_server/chunk_server_file_service_impl.h
+++ b/src/server/chunk_server/chunk_server_file_service_impl.h
@@ -13,9 +13,11 @@ namespace service {
 class ChunkServerFileServiceImpl final
     : public protos::grpc::ChunkServerFileService::Service {
  public:
-  ChunkServerFileServiceImpl(gfs::server::ChunkServerImpl* chunk_server_impl)
+  ChunkServerFileServiceImpl(gfs::server::ChunkServerImpl* chunk_server_impl,
+                             const bool clear_cached_data_after_write = true)
       : protos::grpc::ChunkServerFileService::Service(),
-        chunk_server_impl_(chunk_server_impl) {}
+        chunk_server_impl_(chunk_server_impl),
+        clear_cached_data_after_write_(clear_cached_data_after_write) {}
 
   // Handle an InitFileChunkRequest request sent by the master.
   grpc::Status InitFileChunk(grpc::ServerContext* context,
@@ -55,6 +57,10 @@ class ChunkServerFileServiceImpl final
       gfs::server::FileChunkManager::GetInstance();
 
  private:
+  // Should we clear the cached data after write/apply mutation is done.
+  // Mostly set to false for testing.
+  bool clear_cached_data_after_write_;
+
   // Internal helper method to write file chunk to the local file chunk manager
   // and set reply status to the appropriate FileChunkMutationStatus. This is
   // used by both WriteFileChunk and ApplyMutations, to apply writes locally. It

--- a/src/server/chunk_server/chunk_server_impl.cc
+++ b/src/server/chunk_server/chunk_server_impl.cc
@@ -74,7 +74,7 @@ void ChunkServerImpl::RemoveLease(const std::string& file_handle) {
 
 google::protobuf::util::StatusOr<uint32_t> ChunkServerImpl::GetChunkVersion(
     const std::string& file_handle) {
-   return file_manager_->GetChunkVersion(file_handle);
+  return file_manager_->GetChunkVersion(file_handle);
 }
 
 //
@@ -169,6 +169,12 @@ bool ChunkServerImpl::ReportToMaster() {
   // atleast one master server knows about this chunk server.
   return successful_report > 0;
 }
+
+gfs::common::ConfigManager* ChunkServerImpl::GetConfigManager() const {
+  return config_manager_;
+}
+
+bool ChunkServerImpl::ResolveHostname() const { return resolve_hostname_; }
 
 }  // namespace server
 }  // namespace gfs

--- a/src/server/chunk_server/chunk_server_impl.h
+++ b/src/server/chunk_server/chunk_server_impl.h
@@ -45,8 +45,8 @@ class ChunkServerImpl {
   std::shared_ptr<gfs::service::MasterChunkServerManagerServiceClient>
   GetMasterProtocolClient(const std::string& server_address);
 
-  // Register (create) a protocol client for talking to the master at |server_address|.
-  // Overwrite any existing connection.
+  // Register (create) a protocol client for talking to the master at
+  // |server_address|. Overwrite any existing connection.
   void RegisterMasterProtocolClient(const std::string& server_address);
 
   // Similar to GetMasterProtocolClient, but for talking to chunk servers.
@@ -61,6 +61,12 @@ class ChunkServerImpl {
   // and the master will become aware of them and start issuing chunk
   // allocations to them. Returns true if successful and false otherwise.
   bool ReportToMaster();
+
+  // Get the configuration manager used by the chunkserver
+  gfs::common::ConfigManager* GetConfigManager() const;
+
+  // Check if resolving hostname is enabled
+  bool ResolveHostname() const;
 
  private:
   ChunkServerImpl() = default;
@@ -81,10 +87,10 @@ class ChunkServerImpl {
 
   // Server address and its corresponding GFS protocol client
   // A protocol client will be added the first time the connection is added, and
-  // subsequent calls will simply reuse this protocol client and connection. 
+  // subsequent calls will simply reuse this protocol client and connection.
   // Currently we don't remove connections no longer in use, for simplicity.
   //
-  // Note that this design makes it possible to dynamically add new connections 
+  // Note that this design makes it possible to dynamically add new connections
   // to new servers that may not be present during startup configuration.
   gfs::common::thread_safe_flat_hash_map<
       std::string,

--- a/tests/server/chunk_server/chunk_server_file_impl_test.cc
+++ b/tests/server/chunk_server/chunk_server_file_impl_test.cc
@@ -5,8 +5,10 @@
 #include "google/protobuf/stubs/statusor.h"
 #include "grpcpp/grpcpp.h"
 #include "gtest/gtest.h"
+#include "src/common/config_manager.h"
 #include "src/common/protocol_client/chunk_server_service_gfs_client.h"
 #include "src/common/protocol_client/chunk_server_service_server_client.h"
+#include "src/common/utils.h"
 #include "src/protos/grpc/chunk_server_file_service.grpc.pb.h"
 #include "src/protos/grpc/chunk_server_lease_service.grpc.pb.h"
 #include "src/server/chunk_server/chunk_server_file_service_impl.h"
@@ -14,6 +16,8 @@
 #include "src/server/chunk_server/chunk_server_lease_service_impl.h"
 #include "src/server/chunk_server/file_chunk_manager.h"
 
+using gfs::common::ConfigManager;
+using namespace gfs::common::utils;
 using gfs::server::ChunkServerImpl;
 using gfs::server::FileChunkManager;
 using gfs::service::ChunkServerFileServiceImpl;
@@ -26,10 +30,17 @@ using grpc::Server;
 using grpc::ServerBuilder;
 using protos::grpc::AdvanceFileChunkVersionReply;
 using protos::grpc::AdvanceFileChunkVersionRequest;
+using protos::grpc::FileChunkMutationStatus;
+using protos::grpc::GrantLeaseReply;
+using protos::grpc::GrantLeaseRequest;
 using protos::grpc::InitFileChunkReply;
 using protos::grpc::InitFileChunkRequest;
 using protos::grpc::ReadFileChunkReply;
 using protos::grpc::ReadFileChunkRequest;
+using protos::grpc::SendChunkDataReply;
+using protos::grpc::SendChunkDataRequest;
+using protos::grpc::WriteFileChunkReply;
+using protos::grpc::WriteFileChunkRequest;
 
 const std::string kTestConfigPath = "tests/server/chunk_server/test_config.yml";
 // Initialize this test on port 50052, so it doesn't conflict with lease test
@@ -46,6 +57,9 @@ const std::string kTestFileHandle = "9d2a2342-97f9-11ea";
 const std::string kTestFileHandle_Advanceable = "bb37-0242ac130002";
 const uint32_t kTestFileVersion = 2;
 const std::string kTestData = "Hello, World! This is a dope test";
+
+const uint64_t kTestLeaseExpirationUnixSeconds =
+    absl::ToUnixSeconds(absl::Now() + absl::Hours(1));
 
 namespace {
 void SeedTestData(ChunkServerImpl* chunk_server) {
@@ -65,19 +79,30 @@ void SeedTestData(ChunkServerImpl* chunk_server) {
                                   kTestData);
 }
 
-void StartTestServer() {
-  // Initialize the test chunk server database
-  FileChunkManager::GetInstance()->Initialize("chunk_server_file_impl_test_db",
-                                              /*max_chunk_size_bytes=*/1024);
+void StartTestServer(const std::string& server_address,
+                     const std::string& server_name,
+                     const bool initialize_file_chunk_mgr,
+                     const bool seed_data) {
+  if (initialize_file_chunk_mgr) {
+    // Initialize the test chunk server database
+    FileChunkManager::GetInstance()->Initialize(
+        "chunk_server_file_impl_test_db",
+        /*max_chunk_size_bytes=*/1024);
+  }
 
   ServerBuilder builder;
   auto credentials = grpc::InsecureServerCredentials();
-  builder.AddListeningPort(kTestServerAddress, credentials);
+  builder.AddListeningPort(server_address, credentials);
   StatusOr<ChunkServerImpl*> chunk_server_or =
-      ChunkServerImpl::ConstructChunkServerImpl(kTestConfigPath,
-                                                kTestServerName);
+      ChunkServerImpl::ConstructChunkServerImpl(kTestConfigPath, server_name,
+                                                /*resolve_hostname=*/true);
   ChunkServerImpl* chunk_server = chunk_server_or.ValueOrDie();
-  SeedTestData(chunk_server);  // seed test data
+
+  if (seed_data) {
+    // seed test data
+    SeedTestData(chunk_server);
+  }
+
   ChunkServerLeaseServiceImpl lease_service(chunk_server);
   builder.RegisterService(&lease_service);
   ChunkServerFileServiceImpl file_service(chunk_server);
@@ -103,6 +128,8 @@ class ChunkServerFileImplTest : public ::testing::Test {
     gfs_client_ =
         std::make_shared<ChunkServerServiceGfsClient>(grpc::CreateChannel(
             kTestServerAddress, grpc::InsecureChannelCredentials()));
+    config_mgr_ = std::shared_ptr<ConfigManager>(
+        ConfigManager::GetConfig(kTestConfigPath).ValueOrDie());
   }
 
   ReadFileChunkRequest MakeValidReadFileChunkRequest() {
@@ -124,6 +151,7 @@ class ChunkServerFileImplTest : public ::testing::Test {
   std::shared_ptr<ChunkServerServiceMasterServerClient> master_server_client_;
   std::shared_ptr<ChunkServerServiceChunkServerClient> chunk_server_client_;
   std::shared_ptr<ChunkServerServiceGfsClient> gfs_client_;
+  std::shared_ptr<ConfigManager> config_mgr_;
 };
 
 //
@@ -324,12 +352,193 @@ TEST_F(ChunkServerFileImplTest, AdvanceFileChunkVersionOutOfSyncVersionError) {
             AdvanceFileChunkVersionReply::FAILED_VERSION_OUT_OF_SYNC);
 }
 
+//
+// TEST - Write file chunk and apply mutation
+//
+
+// This tests the write request and apply mutation workflow. Creates multiple
+// chunkservers and write to one as primary and let primary send apply mutation
+// to the replica chunk servers. Test different scenarios such as good write,
+// bad offset, bad version etc.
+TEST_F(ChunkServerFileImplTest, WriteReplicatedFileChunk) {
+  std::string chunk_handle = "WriteReplicatedFileChunk";
+  std::string write_data = "Data for WriteReplicatedFileChunk";
+  std::string write_data_checksum = calc_checksum(write_data);
+
+  // Seed this data in the file chunk manager. Since we are running the test
+  // chunk servers as threads, they'll share the same file chunk manager.
+  FileChunkManager* test_file_manager = FileChunkManager::GetInstance();
+  test_file_manager->CreateChunk(chunk_handle, kTestFileVersion);
+  test_file_manager->WriteToChunk(chunk_handle, kTestFileVersion,
+                                  /*start_offset=*/0, kTestData.length(),
+                                  kTestData);
+
+  std::string primary_chunk_server_name = kTestServerName;
+
+  std::vector<std::string> replica_chunk_server_names = {
+      "write_chunk_server_01", "write_chunk_server_02"};
+
+  std::vector<std::string> all_chunk_server_names(replica_chunk_server_names);
+  all_chunk_server_names.push_back(primary_chunk_server_name);
+
+  std::vector<std::thread> replica_chunk_server_threads;
+
+  // Start replica servers, primary is already running from test main.
+  for (auto& server_name : replica_chunk_server_names) {
+    replica_chunk_server_threads.push_back(std::thread(
+        StartTestServer,
+        config_mgr_->GetServerAddress(server_name, /*resolve_hostname=*/true),
+        server_name,
+        /*initialize_file_chunk_mgr=*/false, /*seed_data=*/false));
+  }
+
+  // Wait for servers to fully initialize
+  std::this_thread::sleep_for(std::chrono::seconds(3));
+
+  // Send data to all servers, trivial no need to parallelize
+  for (auto& server_name : all_chunk_server_names) {
+    ChunkServerServiceGfsClient client(grpc::CreateChannel(
+        config_mgr_->GetServerAddress(server_name, /*resolve_hostname=*/true),
+        grpc::InsecureChannelCredentials()));
+
+    SendChunkDataRequest request;
+    request.set_data(write_data);
+    request.set_checksum(write_data_checksum);
+    auto reply = client.SendRequest(request);
+
+    EXPECT_TRUE(reply.ok());
+    EXPECT_EQ(reply.ValueOrDie().status(), SendChunkDataReply::OK);
+  }
+
+  // Grant primary write lease on file chunk
+  GrantLeaseRequest lease_request;
+  lease_request.set_chunk_handle(chunk_handle);
+  lease_request.set_chunk_version(kTestFileVersion);
+  lease_request.mutable_lease_expiration_time()->set_seconds(
+      kTestLeaseExpirationUnixSeconds);
+
+  auto lease_reply = master_server_client_->SendRequest(lease_request);
+
+  EXPECT_TRUE(lease_reply.ok());
+  EXPECT_EQ(lease_reply.ValueOrDie().status(), GrantLeaseReply::ACCEPTED);
+
+  // Case 1:
+  // Now ask primary to write data, once primary is done it will tell replicas
+  // to write too. This should succeed.
+
+  ChunkServerServiceGfsClient primary_client(grpc::CreateChannel(
+      config_mgr_->GetServerAddress(primary_chunk_server_name,
+                                    /*resolve_hostname=*/true),
+      grpc::InsecureChannelCredentials()));
+
+  // prepare write request
+  WriteFileChunkRequest write_request;
+  auto header = write_request.mutable_header();
+  header->set_chunk_handle(chunk_handle);
+  header->set_chunk_version(kTestFileVersion);
+  header->set_offset_start(0);
+  header->set_length(write_data.size());
+  header->set_data_checksum(write_data_checksum);
+
+  // Add replica locations to write request
+  for (auto& server_name : replica_chunk_server_names) {
+    auto location = write_request.add_replica_locations();
+    location->set_server_hostname(server_name);
+    location->set_server_port(config_mgr_->GetServerPort(server_name));
+  }
+
+  auto write_reply_or = primary_client.SendRequest(write_request);
+
+  EXPECT_TRUE(write_reply_or.ok());
+
+  auto write_reply = write_reply_or.ValueOrDie();
+
+  EXPECT_EQ(write_reply.status(), FileChunkMutationStatus::OK);
+
+  // Check that all replica servers responded
+  EXPECT_EQ(replica_chunk_server_names.size(),
+            write_reply.replica_status_size());
+
+  for (auto& replica : write_reply.replica_status()) {
+    EXPECT_EQ(replica.status(), FileChunkMutationStatus::OK);
+  }
+
+  // Case 2:
+  // Now try to write wrong version. This should fail.
+
+  write_request.mutable_header()->set_chunk_version(kTestFileVersion + 1);
+
+  write_reply_or = primary_client.SendRequest(write_request);
+
+  EXPECT_TRUE(write_reply_or.ok());
+
+  write_reply = write_reply_or.ValueOrDie();
+
+  EXPECT_EQ(write_reply.status(),
+            FileChunkMutationStatus::FAILED_STALE_VERSION);
+
+  // No replica status, since it failed in primary
+  EXPECT_EQ(0, write_reply.replica_status_size());
+
+  // Case 3:
+  // Now try to write wrong offset. This should fail.
+
+  // Set correct version
+  write_request.mutable_header()->set_chunk_version(kTestFileVersion);
+  // Set bad start offset
+  write_request.mutable_header()->set_offset_start(write_data.size() + 5);
+
+  write_reply_or = primary_client.SendRequest(write_request);
+
+  EXPECT_TRUE(write_reply_or.ok());
+
+  write_reply = write_reply_or.ValueOrDie();
+
+  EXPECT_EQ(write_reply.status(), FileChunkMutationStatus::FAILED_OUT_OF_RANGE);
+
+  // No replica status, since it failed in primary
+  EXPECT_EQ(0, write_reply.replica_status_size());
+
+  // Case 4:
+  // Now try to write without sending the data first. This should fail, since
+  // data won't be in cache.
+
+  std::string new_write_data =
+      "Now try to write without sending the data first";
+  std::string new_write_data_checksum = calc_checksum(new_write_data);
+
+  write_request.mutable_header()->set_length(new_write_data.size());
+  write_request.mutable_header()->set_data_checksum(new_write_data_checksum);
+  write_request.mutable_header()->set_offset_start(0);
+
+  write_reply_or = primary_client.SendRequest(write_request);
+
+  EXPECT_TRUE(write_reply_or.ok());
+
+  write_reply = write_reply_or.ValueOrDie();
+
+  EXPECT_EQ(write_reply.status(),
+            FileChunkMutationStatus::FAILED_DATA_NOT_FOUND);
+
+  // No replica status, since it failed in primary
+  EXPECT_EQ(0, write_reply.replica_status_size());
+
+  // kill the replica servers
+  for (std::size_t i = 0; i < replica_chunk_server_threads.size(); ++i) {
+    pthread_cancel(replica_chunk_server_threads[i].native_handle());
+    replica_chunk_server_threads[i].join();
+  }
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   // Start a server for lease gRPC handler in the background, and wait some time
   // for the server to successfully start in background
-  std::thread server_thread = std::thread(StartTestServer);
+  std::thread server_thread =
+      std::thread(StartTestServer, kTestServerAddress, kTestServerName,
+                  /*initialize_file_chunk_mgr=*/true,
+                  /*const bool seed_data =*/true);
   std::this_thread::sleep_for(std::chrono::seconds(3));
 
   // Run tests

--- a/tests/server/chunk_server/test_config.yml
+++ b/tests/server/chunk_server/test_config.yml
@@ -9,6 +9,8 @@ servers:
     - chunk_server_01
     - chunk_server_02
     - chunk_server_03
+    - write_chunk_server_01
+    - write_chunk_server_02
 # Network Information for each server
 # Feel free to change hostname to match Docker config, when applicable
 network:
@@ -24,6 +26,12 @@ network:
   chunk_server_03:
     hostname: chunk_server_03
     port: 50054
+  write_chunk_server_01:
+    hostname: write_chunk_server_01
+    port: 50055
+  write_chunk_server_02:
+    hostname: write_chunk_server_02
+    port: 50056
   dns_lookup_table: # Hostname -> IP address mapping
     # These values should only be used, if no DNS server is available
     # for translating hostname to IP address. If using Docker, docker
@@ -33,6 +41,8 @@ network:
     chunk_server_01: 0.0.0.0
     chunk_server_02: 0.0.0.0
     chunk_server_03: 0.0.0.0
+    write_chunk_server_01: 0.0.0.0
+    write_chunk_server_02: 0.0.0.0
 disk:
   # The block size (MB) for each GFS file chunk
   block_size_mb: 64
@@ -43,6 +53,8 @@ disk:
     chunk_server_01: data/gfs_db_chunk_server_01
     chunk_server_02: data/gfs_db_chunk_server_02
     chunk_server_03: data/gfs_db_chunk_server_03
+    write_chunk_server_01: data/gfs_db_write_chunk_server_01
+    write_chunk_server_02: data/gfs_db_write_chunk_server_02
 timeout:
   # The valid suffixes are "ns", "us" "ms", "s", "m", and "h".
   grpc: 10s


### PR DESCRIPTION
This change includes how the primary chunk server handles write request, and ask replica chunk servers to apply mutation after primary is done writing.

Changes:
1. Implementation for WriteRequest and ApplyMutation
2. Test
3. Add definition for ApplyMutation grpc
4. Fix checksum fields in grpc to use bytes instead of string, because checksum sequence isn't valid UTF-8
5. Verify sent data checksum for SendDataRequests.