### PR TITLE
[fix + test] Add E2E test that writes 100MB file, and fixed bugs 

### DIFF
--- a/src/client/client_impl.cc
+++ b/src/client/client_impl.cc
@@ -571,11 +571,20 @@ void ClientImpl::RegisterChunkServerServiceClient(
     const std::string& server_address) {
   LOG(INFO) << "Establishing new connection to chunk server: "
             << server_address;
+
+  // Specify max message size as the default is only 4MB, add some additional
+  // bytes as the message size is larger than the payload
+  grpc::ChannelArguments channel_args;
+  channel_args.SetMaxReceiveMessageSize(
+      config_manager_->GetFileChunkBlockSize() * gfs::common::bytesPerMb 
+          + 1000);
+  
   chunk_server_service_client_.TryInsert(
       server_address,
       std::make_shared<service::ChunkServerServiceGfsClient>(
-          grpc::CreateChannel(server_address,
-                              grpc::InsecureChannelCredentials())));
+          grpc::CreateCustomChannel(server_address,
+                                    grpc::InsecureChannelCredentials(),
+                                    channel_args)));
 }
 
 std::shared_ptr<service::ChunkServerServiceGfsClient>

--- a/src/server/chunk_server/run_chunk_server_main.cc
+++ b/src/server/chunk_server/run_chunk_server_main.cc
@@ -63,6 +63,12 @@ int main(int argc, char** argv) {
   // Listen on the given address without any authentication mechanism for now.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
 
+  // Chunkserver needs to accept large data and needs to set max message size
+  // as the default is 4MB. We all an additional 1000 bytes as the message may
+  // contain metadata on top of payload
+  builder.SetMaxReceiveMessageSize(config->GetFileChunkBlockSize() * 
+                                       gfs::common::bytesPerMb + 1000);
+
   // Chunk Server implementation
   LOG(INFO) << "Initializing main chunk server...";
   StatusOr<ChunkServerImpl*> chunk_server_impl_or =

--- a/src/server/master_server/master_metadata_service_impl.cc
+++ b/src/server/master_server/master_metadata_service_impl.cc
@@ -253,6 +253,8 @@ grpc::Status MasterMetadataServiceImpl::HandleFileChunkWrite(
     if (!chunk_creation_status.ok()) {
       return chunk_creation_status;
     }
+    // Refetch the chunk handle after creation
+    chunk_handle_or = metadata_manager()->GetChunkHandle(filename, chunk_index);
   }
 
   google::protobuf::util::StatusOr<FileChunkMetadata> file_chunk_metadata_or(

--- a/tests/end_to_end/BUILD.bazel
+++ b/tests/end_to_end/BUILD.bazel
@@ -40,6 +40,17 @@ cc_binary(
     ],
 )
 
+cc_binary(
+    name = "file_medium_size_write_then_read_client",
+    srcs = ["file_medium_size_write_then_read_client.cc"],
+    deps = [
+        "//src/client:gfs_client",
+        "//src/common:system_logger",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+    ],
+)
+
 py_test(
     name = "file_simple_write_read_test",
     timeout = "short",
@@ -51,3 +62,16 @@ py_test(
     ],
     deps = [":end_to_end_lib"],
 )
+
+py_test(
+    name = "file_medium_size_write_then_read_test",
+    srcs = ["file_medium_size_write_then_read_test.py"],
+    data = [
+        ":file_medium_size_write_then_read_client",
+        "//src/server/chunk_server:run_chunk_server_main",
+        "//src/server/master_server:run_master_server_main",
+    ],
+    timeout = "moderate",
+    deps = [":end_to_end_lib"],
+)
+

--- a/tests/end_to_end/file_medium_size_write_then_read_client.cc
+++ b/tests/end_to_end/file_medium_size_write_then_read_client.cc
@@ -72,7 +72,7 @@ void singleFileRead(const std::string& filename_base, ushort id) {
 
   auto read_data(read_data_or.ValueOrDie());
   if (memcmp(read_data.buffer, kGlobalFileData.c_str(), 
-             kGlobalFileData.size() != 0)) {
+             kGlobalFileData.size()) != 0) {
     LOG(ERROR) << "Read request in the " + std::to_string(id) 
                << " receives incorrect data";
     exit(1);

--- a/tests/end_to_end/file_medium_size_write_then_read_client.cc
+++ b/tests/end_to_end/file_medium_size_write_then_read_client.cc
@@ -1,0 +1,140 @@
+#include <thread>
+#include <vector>
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "src/client/gfs_client.h"
+#include "src/common/system_logger.h"
+
+ABSL_FLAG(std::string, config_path, "file_medium_size_write_then_read_test/config.yaml", 
+          "/path/to/config.yml");
+ABSL_FLAG(std::string, master_name, "master_server_01",
+          "master name for this client to talk to");
+
+// We write 100MB data, which causes multiple (2) chunks to be created for a file
+const size_t kGlobalFileDataSize = 100 * 1024 * 1024;
+
+// Initialize the data by randomly generation
+const std::string InitializeData() {
+  static const char alphanum[] 
+      = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  std::string data;
+  data.resize(kGlobalFileDataSize);
+  
+  for (size_t i = 0; i < kGlobalFileDataSize; ++i) {
+    data[i] = alphanum[rand() % (sizeof(alphanum) - 1)];
+  }
+
+  return data;
+}
+
+const std::string kGlobalFileData = InitializeData();
+
+// Init function to initialize the client
+void init() {
+  const std::string config_path = absl::GetFlag(FLAGS_config_path);
+  const std::string master_name = absl::GetFlag(FLAGS_master_name);
+  const bool resolve_hostname(true);
+
+  LOG(INFO) << "Calling init_client...";
+  auto init_status(gfs::client::init_client(config_path, master_name, 
+                                            resolve_hostname));
+  if (!init_status.ok()) {
+    LOG(ERROR) << "Client initialization failed with error: " 
+               << init_status.error_message();
+    exit(-1);
+  }
+}
+
+// Read a file, verify its content
+void singleFileRead(const std::string& filename_base, ushort id) {
+  init();
+  const std::string filename(filename_base + std::to_string(id));
+  auto open_file_status(gfs::client::open(filename.c_str(),
+                                          gfs::OpenFlag::Read));
+  if (!open_file_status.ok()) {
+    LOG(ERROR) << "Open to read " + filename + " failed with error: "
+               << open_file_status;
+    exit(1);
+  } else {
+    LOG(INFO) << "Open to read " + filename + " succeeded";
+  }
+
+  auto read_data_or(gfs::client::read(
+      filename.c_str(), 0, kGlobalFileData.size()));
+
+  if (!read_data_or.ok()) {
+    LOG(ERROR) << "Read request in the " + std::to_string(id) 
+               << "-th thread failed due to: " << read_data_or.status();
+    exit(1);
+  } else {
+    LOG(INFO) << "Read request in the " + std::to_string(id) << " succeeded"; 
+  }
+
+  auto read_data(read_data_or.ValueOrDie());
+  if (memcmp(read_data.buffer, kGlobalFileData.c_str(), 
+             kGlobalFileData.size() != 0)) {
+    LOG(ERROR) << "Read request in the " + std::to_string(id) 
+               << " receives incorrect data";
+    exit(1);
+  } else {
+    LOG(INFO) << "Read request in the " + std::to_string(id)
+              << " receives correct data";
+  }
+}
+
+// Write a file and then read it from a different thread (so acting as a 
+// different client), verify the read
+void singleFileWriteThenRead(const std::string& filename_base, ushort id) {
+  init();
+  const std::string filename(filename_base + std::to_string(id));
+  auto create_file_status(gfs::client::open(filename.c_str(),
+                                            gfs::OpenFlag::Create));
+  if (!create_file_status.ok()) {
+    LOG(ERROR) << "Open to create " + filename + " failed with error: "
+               << create_file_status;
+    exit(1);
+  } else {
+    LOG(INFO) << "Open to create " + filename + " succeeded";
+  }
+
+  auto write_status(gfs::client::write(
+      filename.c_str(), (void*)kGlobalFileData.c_str(), 0, 
+      kGlobalFileData.size()));
+
+  if (!write_status.ok()) {
+    LOG(ERROR) << "Write request in the " + std::to_string(id) 
+               << "-th thread failed due to: " << write_status;
+    exit(1);
+  } else {
+    LOG(INFO) << "Write request in the " + std::to_string(id) << " succeeded"; 
+  }
+
+  // After successful write, spawn a reader thread and read to verify the write
+  std::thread reader_thread(singleFileRead, filename_base, id);
+  reader_thread.join();
+}
+
+// Launch a number of threads, and each thread first write a medium-size file 
+// (kGlobalFileData), and then spawn a separate thread to read the file and 
+// verify the data.
+void parallelFileWriteThenRead(const std::string& filename_base,
+                               const ushort num_of_threads) {
+  std::vector<std::thread> threads;
+  for (auto i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread(singleFileWriteThenRead, filename_base, i));
+  }
+
+  for(auto& t : threads) {
+    t.join();
+  }
+}
+
+int main(int argc, char** argv) {
+  // Initialize system log and parse command line options
+  gfs::common::SystemLogger::GetInstance().Initialize(argv[0]);
+  absl::ParseCommandLine(argc, argv);
+
+  parallelFileWriteThenRead("/baz", 3);
+
+  return 0;
+}

--- a/tests/end_to_end/file_medium_size_write_then_read_test.py
+++ b/tests/end_to_end/file_medium_size_write_then_read_test.py
@@ -23,9 +23,6 @@ def test_main():
     server_procs = end_to_end_lib.start_master_and_chunk_servers(
                        config_filename, log_directory)
 
-    #import time
-    #time.sleep(1000)
-
     # Launch client process as writer
     client = subprocess.Popen(
         ["tests/end_to_end/file_medium_size_write_then_read_client"])

--- a/tests/end_to_end/file_medium_size_write_then_read_test.py
+++ b/tests/end_to_end/file_medium_size_write_then_read_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import atexit
+import end_to_end_lib
+import os
+import signal
+import subprocess
+
+# Launch a server cluster with default setting (1 master + 3 chunk servers)
+# Execute a client process that writes to a medium-size file (100MB) and
+# also verifies that the write is correct
+
+# Called when script exiting to prevent dangling processes
+def handle_processes_cleanup(procs):
+    end_to_end_lib.kill_all_processes(procs)
+
+def test_main():
+    # Create a designated folder for this test
+    test_case_name = "file_medium_size_write_then_read_test"
+    end_to_end_lib.setup_test_directory(test_case_name)
+    # Launch the cluster 
+    config_filename = test_case_name + "/" + "config.yaml"
+    log_directory = test_case_name + "/" + "logs"
+    server_procs = end_to_end_lib.start_master_and_chunk_servers(
+                       config_filename, log_directory)
+
+    #import time
+    #time.sleep(1000)
+
+    # Launch client process as writer
+    client = subprocess.Popen(
+        ["tests/end_to_end/file_medium_size_write_then_read_client"])
+ 
+    atexit.register(handle_processes_cleanup, server_procs + [client])
+    
+    # We expect client to finish successfully
+    client.communicate()
+    assert client.returncode == 0
+  
+    # Cleanup server processes
+    end_to_end_lib.kill_all_processes(server_procs)
+
+if __name__ == "__main__":
+    test_main()

--- a/tests/end_to_end/file_medium_size_write_then_read_test.py
+++ b/tests/end_to_end/file_medium_size_write_then_read_test.py
@@ -20,8 +20,11 @@ def test_main():
     # Launch the cluster 
     config_filename = test_case_name + "/" + "config.yaml"
     log_directory = test_case_name + "/" + "logs"
+    # We configure grpc timeout to be 30s as there are grpc calls that send
+    # 64MB data in one shot
     server_procs = end_to_end_lib.start_master_and_chunk_servers(
-                       config_filename, log_directory)
+                       config_filename, log_directory,
+                       grpc_timeout_s = 30)
 
     # Launch client process as writer
     client = subprocess.Popen(

--- a/tests/end_to_end/file_simple_write_read_client.cc
+++ b/tests/end_to_end/file_simple_write_read_client.cc
@@ -97,7 +97,7 @@ void singleFileRead(const std::string& filename_base, ushort id) {
 
   auto read_data(read_data_or.ValueOrDie());
   if (memcmp(read_data.buffer, kGlobalFileData[id].c_str(), 
-            kGlobalFileData[id].size() != 0)) {
+            kGlobalFileData[id].size()) != 0) {
     LOG(ERROR) << "Read request in the " + std::to_string(id) 
               << " receives incorrect data";
     exit(1);

--- a/tests/end_to_end/file_simple_write_read_test.py
+++ b/tests/end_to_end/file_simple_write_read_test.py
@@ -24,9 +24,6 @@ def test_main():
     server_procs = end_to_end_lib.start_master_and_chunk_servers(
                       config_filename, log_directory)
 
-    # import time
-    # time.sleep(1000)
-
     # Launch client process as writer
     writer_client = subprocess.Popen(
         ["tests/end_to_end/file_simple_write_read_client", "--is_writer"])


### PR DESCRIPTION
In this PR, we continue to ad E2E test. The test case writes a 100MB file, which crosses two chunks for each file. The test have separate agents to write in parallel (to different files) with random strings, and verify that the results with read. 

This PR fixed two main things:

1) Both client and chunk server needs to configure its max message size as the default is 4MB but a chunk size is 64MB

2) There is a bug in HandleWriteFileChunk, when we ended up creating a chunk on the fly we need to fetch the chunk handle. 