### PR TITLE
[feat + fix] Support deleting file and file chunks garbage collection

### DIFF
--- a/gfs_client_main.cc
+++ b/gfs_client_main.cc
@@ -107,8 +107,13 @@ int main(int argc, char** argv) {
       return 1;
     }
   } else if (mode == "remove") {
-    LOG(ERROR) << "Remove Not implemented yet";
-    return 1;
+    Status remove_status = gfs::client::remove(filename.c_str());
+    if (remove_status.ok()) {
+      LOG(INFO) << "File removed";
+    } else {
+      LOG(ERROR) << "Failed to remove: " << remove_status;
+      return 1;
+    }
   }
 
   return 0;

--- a/src/client/client_impl.cc
+++ b/src/client/client_impl.cc
@@ -9,6 +9,7 @@
 
 using google::protobuf::util::Status;
 using google::protobuf::util::StatusOr;
+using protos::grpc::DeleteFileRequest;
 using protos::grpc::FileChunkMutationStatus;
 using protos::grpc::OpenFileReply;
 using protos::grpc::OpenFileRequest;
@@ -565,6 +566,16 @@ google::protobuf::util::Status ClientImpl::WriteFile(const char* filename,
   }
 
   return google::protobuf::util::Status::OK;
+}
+
+google::protobuf::util::Status ClientImpl::DeleteFile(
+    const std::string& filename) {
+  // Prepare the DeleteFileRequest and client context
+  DeleteFileRequest delete_file_request;
+  delete_file_request.set_filename(filename);
+  grpc::ClientContext client_context;
+  common::SetClientContextDeadline(client_context, config_manager_);
+  return master_metadata_service_client_->SendRequest(delete_file_request);
 }
 
 void ClientImpl::RegisterChunkServerServiceClient(

--- a/src/client/client_impl.h
+++ b/src/client/client_impl.h
@@ -34,6 +34,9 @@ class ClientImpl {
   google::protobuf::util::Status WriteFile(const char* filename, void* buffer,
       size_t offset, size_t nbytes);
 
+  // Internal impl call that issues a DeleteFileRequest to the master
+  google::protobuf::util::Status DeleteFile(const std::string& filename); 
+
   // Construct and return a ClientImpl objects with proper configurations 
   // using the given config file. The ClientImpl object uses the config 
   // file to initialize the cache manager and two clients objects used to 

--- a/src/client/gfs_client.cc
+++ b/src/client/gfs_client.cc
@@ -137,7 +137,7 @@ google::protobuf::util::Status write(const char* filename, void* buffer,
 }
 
 google::protobuf::util::Status remove(const char* filename) {
-  return google::protobuf::util::Status::OK;
+  return client_impl_->DeleteFile(filename);
 }
 
 }  // namespace client

--- a/src/server/chunk_server/chunk_server_impl.h
+++ b/src/server/chunk_server/chunk_server_impl.h
@@ -1,6 +1,8 @@
 #ifndef GFS_SERVER_CHUNK_SERVER_IMPL_H_
 #define GFS_SERVER_CHUNK_SERVER_IMPL_H_
 
+#include <thread>
+
 #include "absl/container/flat_hash_map.h"
 #include "absl/time/time.h"
 #include "google/protobuf/stubs/statusor.h"
@@ -62,6 +64,14 @@ class ChunkServerImpl {
   // allocations to them. Returns true if successful and false otherwise.
   bool ReportToMaster();
 
+  // Start calling ReportToMaster periodically to master server. For 
+  // dynamically adding chunk servers and for garbage collecting deleted chunks
+  void StartReportToMaster();
+
+  // Instruct to terminate the reporting threads by stopping its service and
+  // joining them. This function call is useful when peacefully teardown
+  void TerminateReportToMaster(); 
+
   // Get the configuration manager used by the chunkserver
   gfs::common::ConfigManager* GetConfigManager() const;
 
@@ -108,6 +118,12 @@ class ChunkServerImpl {
   // Write leases that chunk server holds, and their respective expiration time
   gfs::common::thread_safe_flat_hash_map<std::string, uint64_t>
       lease_and_expiration_unix_sec_;
+ 
+  // A separate thread that executes the ReportToMaster periodically
+  std::thread* chunk_reporting_thread_;
+
+  // An atomic flag to terminate the reporting thread
+  std::atomic<bool> reporting_thread_terminated_{false};
 };
 
 }  // namespace server

--- a/src/server/chunk_server/run_chunk_server_main.cc
+++ b/src/server/chunk_server/run_chunk_server_main.cc
@@ -96,15 +96,12 @@ int main(int argc, char** argv) {
     chunk_server_impl->RegisterMasterProtocolClient(master_server_address);
   }
 
-  // This chunkserver should report itself to the master server(s). This will
-  // enable the master be aware of this chunkserver, and to start selecting it
-  // for chunk allocation. This also allows chunk servers to be dynamically
-  // added since they just need to report themselves to master.
-  if (!chunk_server_impl->ReportToMaster()) {
-    LOG(ERROR) << "Failed to report to any master server. Probably no master "
-                  "server is running. Shutting down...";
-    return 1;
-  }
+  // Start report chunks to the master periodically, this chunkserver should 
+  // report itself to the master server(s). This will enable the master be aware
+  // of this chunkserver, and to start selecting it for chunk allocation. This 
+  // also allows chunk servers to be dynamically added since they just need to 
+  // report themselves to master.
+  chunk_server_impl->StartReportToMaster();
 
   // Register synchronous services for handling clients' metadata requests
   // Note that gRPC only support providing services through via a single port.
@@ -124,6 +121,9 @@ int main(int argc, char** argv) {
   // Wait for the server to shutdown. Note that some other thread must be
   // responsible for shutting down the server for this call to ever return.
   server->Wait();
+
+  // Terminate the reporting service
+  chunk_server_impl->TerminateReportToMaster();
 
   return 0;
 }

--- a/src/server/master_server/BUILD.bazel
+++ b/src/server/master_server/BUILD.bazel
@@ -102,7 +102,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":chunk_server_manager",
+        ":metadata_manager",
         "//src/common:config_manager",
+        "//src/common:system_logger",
         "//src/protos/grpc:cc_master_chunk_server_manager_service_grpc",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/src/server/master_server/master_chunk_server_manager_service_impl.cc
+++ b/src/server/master_server/master_chunk_server_manager_service_impl.cc
@@ -5,8 +5,10 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
 #include "grpcpp/grpcpp.h"
+#include "src/common/system_logger.h"
 #include "src/protos/grpc/master_chunk_server_manager_service.grpc.pb.h"
 #include "src/server/master_server/chunk_server_manager.h"
+#include "src/server/master_server/metadata_manager.h"
 
 using grpc::ServerContext;
 using protos::grpc::ReportChunkServerReply;
@@ -34,6 +36,7 @@ grpc::Status MasterChunkServerManagerServiceImpl::ReportChunkServer(
     ServerContext* context, const ReportChunkServerRequest* request,
     ReportChunkServerReply* reply) {
   auto& new_server_info = request->chunk_server();
+  LOG(INFO) << "Master handling report from " << new_server_info.DebugString();
   auto existing_server_info =
       gfs::server::ChunkServerManager::GetInstance().GetChunkServer(
           new_server_info.location());
@@ -62,6 +65,24 @@ grpc::Status MasterChunkServerManagerServiceImpl::ReportChunkServer(
     // The chunks that we think exist on the chunkserver but no longer exist
     // on it.
     absl::flat_hash_set<std::string> chunks_to_remove;
+
+    // Check for deleted chunk with metadata mgr. If a chunk handle is found
+    // deleted, we add it to stale chunks in reply so chunk server can delete
+    // them.
+    // TODO(Xi/bmokutub): Not sure if this piece of logic should / need to be 
+    // combined with below. TBD
+    for(auto stored_chunk_handles : 
+            request->chunk_server().stored_chunk_handles()) {
+      if (!gfs::server::MetadataManager::GetInstance()->ExistFileChunkMetadata(
+              stored_chunk_handles)) {
+         LOG(INFO) << "Chunk handle " << stored_chunk_handles 
+                   << " no longer existed in the master's metadata,"
+                   << " marking as staled chunk to chunk server "
+                   << new_server_info.DebugString();
+         reply->mutable_stale_chunk_handles()->Add(
+             std::move(stored_chunk_handles));
+      }
+    }
 
     // Compare with our stored chunk handles for the chunk server. To see
     // which reported chunks we have or don't have.

--- a/src/server/master_server/master_metadata_service_impl.cc
+++ b/src/server/master_server/master_metadata_service_impl.cc
@@ -499,8 +499,15 @@ grpc::Status MasterMetadataServiceImpl::OpenFile(ServerContext* context,
 grpc::Status MasterMetadataServiceImpl::DeleteFile(
     ServerContext* context, const DeleteFileRequest* request,
     google::protobuf::Empty* reply) {
-  // TODO(everyone): implement the GFS master server logic here
-  return grpc::Status(grpc::StatusCode::UNIMPLEMENTED, "needs implementation");
+  // Delete the file metadata, and all chunk metadata associated with a file
+  // when processing a delete file request. Note that this action only deletes
+  // the metadata and the garbage collection of actual chunk is achieved by 
+  // the heartbeat mechanism between master and chunk servers. 
+  const std::string& filename(request->filename());
+  LOG(INFO) << "Trying to delete file and chunk metadata associated with "
+            << filename;
+  metadata_manager()->DeleteFileMetadata(filename);
+  return grpc::Status::OK;
 }
 
 }  // namespace service

--- a/src/server/master_server/metadata_manager.cc
+++ b/src/server/master_server/metadata_manager.cc
@@ -131,9 +131,6 @@ MetadataManager::CreateChunkHandle(const std::string& filename,
   new_chunk_metadata.set_chunk_handle(new_chunk_handle);
   SetFileChunkMetadata(new_chunk_metadata);
 
-  // TODO(Xi,Michael): Call ChunkServerManager::AllocateChunkServers to
-  // allocate chunk servers for this new chunk handle
-
   return new_chunk_handle;
 }
 
@@ -213,6 +210,10 @@ void MetadataManager::SetFileChunkMetadata(
   chunk_metadata_.SetValue(chunk_handle, chunk_data);
 }
 
+void MetadataManager::DeleteFileChunkMetadata(const std::string& chunk_handle) {
+  chunk_metadata_.Erase(chunk_handle);
+}
+
 void MetadataManager::SetPrimaryLeaseMetadata(
     const std::string& chunk_handle,
     const protos::ChunkServerLocation& server_location,
@@ -232,22 +233,46 @@ MetadataManager::GetPrimaryLeaseMetadata(const std::string& chunk_handle) {
   return lease_holders_.TryGetValue(chunk_handle);
 }
 
-// TODO(Xi): In phase 1 the deletion of file is not fully supported but
-// it would be good to lay out a plan as deletion involves removing items
-// from the shared states. When DeleteFileMetadata is called, the following
-// steps should be taken:
-// 1) Loop over all chunk handles for a file, and mark them as deleted
-// by inserting them to deleted_chunk_handles
-// 2) Mark their entries in chunk_metadata_ as default
-//
-// We defer the removal of these entries from the above collections to
-// when the chunks have been garbage collected. By then we
-// 1) Remove the entry in file_metadata_ (TODO) there is still a bit of
-// detailed question here as to how to detect the filename when garbage
-// collection occurs on chunk level
-// 2) Remove the entry in chunk_version_ and chunk_metadata_
+// Delete the file metadata, furthermore, delete all chunk handles assocated
+// with that file metadata, this means all the associated chunk metadata
+// are removed from the metadata manager. The chunk server will detect the 
+// corresonding chunk handle is no longer existing and therefore garbage collect
+// them when finding them out via heartbeat mechanism.
+// Note that we do not rename upon deletion as described from the paper. 
 void MetadataManager::DeleteFileMetadata(const std::string& filename) {
-  // [TODO]: phase 2
+  // Step 1. readlock the parent directories
+  ParentLocksAnchor parentLockAnchor(lock_manager_, filename);
+  if (!parentLockAnchor.ok()) {
+    // If this operation fails, which means some of the parent directory
+    // does not exist, we just return as the deletion is a no-op
+    return;
+  }
+
+  // Step 2. writelock the lock for this path
+  auto path_lock_or(lock_manager_->FetchLock(filename));
+  if (!path_lock_or.ok()) {
+    return;
+  }
+
+  // This writer lock to protect this file, as we are deleting it
+  absl::WriterMutexLock path_writer_lock_guard(path_lock_or.ValueOrDie());
+
+  // Step 3. fetch the file metadata
+  auto file_metadata_or(GetFileMetadata(filename));
+  if (!file_metadata_or.ok()) {
+    return;
+  }
+  auto file_metadata(file_metadata_or.ValueOrDie());
+
+  // Now we can remove the smart pointer of the file metadata from the 
+  // file_metadata collection
+  file_metadata_.Erase(filename);
+
+  // We can still access the file metadata as the shared pointer anchored it
+  // Delete all the file chunk metadata
+  for (auto& chunk_index_and_chunk_handle : file_metadata->chunk_handles()) {
+    DeleteFileChunkMetadata(chunk_index_and_chunk_handle.second);  
+  }
 }
 
 std::string MetadataManager::AllocateNewChunkHandle() {

--- a/src/server/master_server/metadata_manager.cc
+++ b/src/server/master_server/metadata_manager.cc
@@ -200,6 +200,10 @@ google::protobuf::util::Status MetadataManager::AdvanceChunkVersion(
   return google::protobuf::util::Status::OK;
 }
 
+bool MetadataManager::ExistFileChunkMetadata(const std::string& chunk_handle) {
+  return chunk_metadata_.Contains(chunk_handle);
+}
+
 google::protobuf::util::StatusOr<protos::FileChunkMetadata>
 MetadataManager::GetFileChunkMetadata(const std::string& chunk_handle) {
   auto try_get_chunk_data(chunk_metadata_.TryGetValue(chunk_handle));

--- a/src/server/master_server/metadata_manager.h
+++ b/src/server/master_server/metadata_manager.h
@@ -71,6 +71,9 @@ class MetadataManager {
   // Set the chunk metadata for a given chunk handle
   void SetFileChunkMetadata(const protos::FileChunkMetadata& chunk_data);
 
+  // Delete the file chunk metadata for a given chunk handle
+  void DeleteFileChunkMetadata(const std::string& chunk_handle);
+
   // Set the primary chunk location that holds the lease for a given chunk
   // handle, and its lease expiration time
   void SetPrimaryLeaseMetadata(

--- a/src/server/master_server/metadata_manager.h
+++ b/src/server/master_server/metadata_manager.h
@@ -62,6 +62,9 @@ class MetadataManager {
   // chunk handle not found
   google::protobuf::util::Status AdvanceChunkVersion(
       const std::string& chunk_handle);
+ 
+  // Check whether file chunk metadata exists
+  bool ExistFileChunkMetadata(const std::string& chunk_handle);
 
   // Get the chunk metadata for a given chunk handle, return error if
   // chunk handle not found

--- a/tests/end_to_end/BUILD.bazel
+++ b/tests/end_to_end/BUILD.bazel
@@ -29,6 +29,16 @@ py_test(
     deps = [":end_to_end_lib"],
 )
 
+py_test(
+    name = "file_creation_retry_test",
+    srcs = ["file_creation_retry_test.py"],
+    data = [
+        "//:gfs_client_main",
+        "//src/server/chunk_server:run_chunk_server_main",
+        "//src/server/master_server:run_master_server_main",
+    ]
+)
+
 cc_binary(
     name = "file_simple_write_read_client",
     srcs = ["file_simple_write_read_client.cc"],

--- a/tests/end_to_end/file_creation_retry_test.py
+++ b/tests/end_to_end/file_creation_retry_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import atexit
+import end_to_end_lib
+import os
+import signal
+import subprocess
+
+# Purposely introduce an error during file creation by only launching the
+# master server first, after that launch the chunk servers and make sure that
+# the retry is successful. This makes sure that the MasterMetadataService roll
+# back the file metadata if the file metadata creation succeeded but it failed
+# to find chunk server to create the chunk
+
+# Called when script exiting to prevent dangling processes
+def handle_processes_cleanup(procs):
+    end_to_end_lib.kill_all_processes(procs)
+
+def test_main():
+    # Create a designated folder for this test
+    test_case_name = "file_creation_retry_test"
+    end_to_end_lib.setup_test_directory(test_case_name)
+    # Launch the cluster 
+    config_filename = test_case_name + "/" + "config.yaml"
+    log_directory = test_case_name + "/" + "logs"
+    # Only start the master
+    master_proc = end_to_end_lib.start_master_and_chunk_servers(
+                      config_filename, log_directory, start_chunk = False)
+
+    # Launch client process, this process should fail as there is no chunk
+    # server so no chunk allocation done for the first chunk
+    client_proc = subprocess.Popen(["gfs_client_main", 
+                                    "--config_path=" + config_filename,
+                                    "--filename=/foo",
+                                    "--mode=create"])
+    client_proc.communicate()
+    assert client_proc.returncode != 0
+
+    # Launch chunk servers, make it a full cluster
+    chunk_procs = end_to_end_lib.start_master_and_chunk_servers(
+                      config_filename, log_directory, start_master = False)
+
+    # Launch client to create file again, this time should be successful as
+    # the cluster is up
+    client_proc = subprocess.Popen(["gfs_client_main", 
+                                    "--config_path=" + config_filename,
+                                    "--filename=/foo",
+                                    "--mode=create"])
+    client_proc.communicate()
+    assert client_proc.returncode == 0
+
+    # Register cleanup callback
+    atexit.register(handle_processes_cleanup, master_proc + chunk_procs)
+    
+    # Cleanup server processes
+    end_to_end_lib.kill_all_processes(master_proc + chunk_procs)
+
+if __name__ == "__main__":
+    test_main()

--- a/tests/end_to_end/file_medium_size_write_then_read_client.cc
+++ b/tests/end_to_end/file_medium_size_write_then_read_client.cc
@@ -82,6 +82,7 @@ void singleFileRead(const std::string& filename_base, ushort id) {
     LOG(INFO) << "Read request in the " + std::to_string(id)
               << " receives correct data";
   }
+  free(read_data.buffer);
 }
 
 // Write a file and then read it from a different thread (so acting as a 

--- a/tests/end_to_end/file_simple_write_read_client.cc
+++ b/tests/end_to_end/file_simple_write_read_client.cc
@@ -105,6 +105,7 @@ void singleFileRead(const std::string& filename_base, ushort id) {
     LOG(INFO) << "Read request in the " + std::to_string(id)
               << " receives correct data";
   }
+  free(read_data.buffer);
 }
 
 // Launch a number of threads and each to create and write to a different file

--- a/tests/server/master_server/metadata_manager_unit_test.cc
+++ b/tests/server/master_server/metadata_manager_unit_test.cc
@@ -483,3 +483,119 @@ TEST_F(MetadataManagerUnitTest, UpdateChunkMetadataInParallelTest) {
     }
   }
 }
+
+// Have some simple concurrent creation / deletion, first create file "del0",
+// then create file "del1", and delete "del0" concurrently, then create file 
+// "del2", and delete "del1" concurrently. Make sure that at the end only the 
+// last file is present
+TEST_F(MetadataManagerUnitTest, FileDeletionTest) {
+  std::string filename_base("/FileToBeDeleted");
+  int num_of_threads(24);
+  int num_of_chunk_per_file(10);
+  metadata_manager_->CreateFileMetadata(filename_base + "0");
+  EXPECT_TRUE(metadata_manager_->ExistFileMetadata(filename_base + "0"));
+  std::vector<std::thread> threads;
+  // Store the chunk_handles that are supposed to be deleted in this test
+  gfs::common::thread_safe_flat_hash_set<std::string> deleted_chunk_handles;
+
+  for (int i = 1; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string filename_to_be_deleted(filename_base + std::to_string(i-1));
+      metadata_manager_->DeleteFileMetadata(filename_to_be_deleted);
+    }));
+
+    threads.push_back(std::thread([&, i]() {
+      std::string filename_to_be_created(filename_base + std::to_string(i));
+      metadata_manager_->CreateFileMetadata(filename_to_be_created);
+      for (int j = 0; j < num_of_chunk_per_file; j++) {
+        auto chunk_handle_or = 
+            metadata_manager_->CreateChunkHandle(filename_to_be_created, j);
+        auto chunk_handle(chunk_handle_or.ValueOrDie());
+        // If this is not the last batch, it would get deleted so mark them
+        if (i < num_of_threads - 1) {
+          deleted_chunk_handles.insert(chunk_handle);
+        }
+
+        protos::FileChunkMetadata chunk_data;
+        InitializeChunkMetadata(chunk_data, chunk_handle, 0,
+                                std::make_pair("localhost", 5000),
+                                {std::make_pair("localhost", 5000 + j),
+                                 std::make_pair("localhost", 5001 + j),
+                                 std::make_pair("localhost", 5002)});
+        metadata_manager_->SetFileChunkMetadata(chunk_data);
+      }
+    }));
+
+    // Join every time, so that in the next iteration we know that the (i-1)-th
+    // file exists
+    JoinAndClearThreads(threads);
+  }
+
+  // Verify that only the last file exists, and all chunk handles that are 
+  // supposed to be deleted were deleted
+  for (int i = 0; i < num_of_threads; i++) {
+    std::string filename(filename_base + std::to_string(i));
+    if (i < num_of_threads - 1) {
+      EXPECT_FALSE(metadata_manager_->ExistFileMetadata(filename));
+    } else {
+      EXPECT_TRUE(metadata_manager_->ExistFileMetadata(filename));
+    }
+  }
+
+  for(auto& deleted_chunk_handle : deleted_chunk_handles) {
+    auto get_chunk_data(metadata_manager_->GetFileChunkMetadata(
+                            deleted_chunk_handle));
+    EXPECT_FALSE(get_chunk_data.ok());
+    EXPECT_EQ(get_chunk_data.status().error_code(),
+              google::protobuf::util::error::NOT_FOUND);
+  }
+}
+
+// Test creates a number of files and concurrently delete them
+TEST_F(MetadataManagerUnitTest, FileDeletionConcurrentTest) {
+  std::string filename_base("/FileConcurrentDeletion");
+  int num_of_threads(24);
+  int num_of_chunk_per_file(10);
+  std::vector<std::thread> threads;
+  gfs::common::thread_safe_flat_hash_set<std::string> deleted_chunk_handles;
+
+  for (int i = 0; i < num_of_threads; i++) {
+    auto filename(filename_base + std::to_string(i));
+    metadata_manager_->CreateFileMetadata(filename);
+    for (int j = 0; j < num_of_chunk_per_file; j++) {
+      auto chunk_handle(
+          metadata_manager_->CreateChunkHandle(filename, j).ValueOrDie());
+      protos::FileChunkMetadata chunk_data;
+      InitializeChunkMetadata(chunk_data, chunk_handle, 0,
+                              std::make_pair("localhost", 5000),
+                              {std::make_pair("localhost", 5000 + j),
+                               std::make_pair("localhost", 5001 + j),
+                               std::make_pair("localhost", 5002)});
+      metadata_manager_->SetFileChunkMetadata(chunk_data);
+      deleted_chunk_handles.insert(chunk_handle);
+    }
+  }
+
+  // Delete concurrently
+  for (int i = 0; i < num_of_threads; i++) {
+    threads.push_back(std::thread([&, i]() {
+      std::string filename(filename_base + std::to_string(i));
+      metadata_manager_->DeleteFileMetadata(filename);
+    }));
+  }
+  JoinAndClearThreads(threads);
+
+  // Verify that no file exists nor chunk_handle
+  for (int i = 0; i < num_of_threads; i++) {
+    std::string filename(filename_base + std::to_string(i));
+    EXPECT_FALSE(metadata_manager_->ExistFileMetadata(filename));
+  }
+
+  for(auto& deleted_chunk_handle : deleted_chunk_handles) {
+    auto get_chunk_data(metadata_manager_->GetFileChunkMetadata(
+                            deleted_chunk_handle));
+    EXPECT_FALSE(get_chunk_data.ok());
+    EXPECT_EQ(get_chunk_data.status().error_code(),
+              google::protobuf::util::error::NOT_FOUND);
+  }
+}


### PR DESCRIPTION
In this PR, we provide the basic support for deleting file and file chunks. This change includes:

1) MetadataManager level support of deleting file, and all chunk metadata associated with that file
2) Support of File deletion, which is orchestrated among client, master and chunk server. The master deletes the file and chunk metadata immediately and return; Expected the ReportChunkServer service to occur periodically so that master can notify chunk servers regarding deleted chunk handles. 
3) Fixed the bug that when a file creation failed due to no chunk allocated, metadata manager needs to roll back the metadata creation. Added a E2E test to prevent regression. 

The garbage collection of chunks has been manually verified (as logs emit). 